### PR TITLE
Cap file size at 2GB that Amiga sees

### DIFF
--- a/Software/a314fs/a314fs.py
+++ b/Software/a314fs/a314fs.py
@@ -326,6 +326,7 @@ def process_examine_object(key):
         size = 0
         type_ = ST_USERDIR
 
+    size = min(size, 2 ** (31 - 1))
     return struct.pack('>HHHhIIIIIB', 1, 0, 666, type_, size, 0, days, mins, ticks, len(fn)) + fn
 
 def process_examine_next(key, disk_key):
@@ -359,6 +360,7 @@ def process_examine_next(key, disk_key):
         size = 0
         type_ = ST_USERDIR
 
+    size = min(size, 2 ** (31 - 1))
     return struct.pack('>HHHhIIIIIB', 1, 0, disk_key, type_, size, 0, days, mins, ticks, len(fn)) + fn
 
 next_fp = 1


### PR DESCRIPTION
It is rare that the Amiga OS is able to handle >2GB file size. This
guard gives the Amiga OS access to the first 2GB of files greater
than this barrier.