### PR TITLE
Added depencencies for Raspian Lite

### DIFF
--- a/Software/README.md
+++ b/Software/README.md
@@ -8,6 +8,7 @@ On the Raspberry Pi do the following:
 - Install Raspbian: https://www.raspberrypi.org/downloads/raspbian/
 - Install Docker: ```curl -sSL https://get.docker.com | sh```
 - Allow user pi to run Docker: ```sudo usermod -aG docker pi```
+- Install Dependencies: ```sudo apt install python3-dev python3-distutils build-essential git```
 - Clone the a314 repo: ```git clone https://github.com/niklasekstrom/a314.git```
 - ```cd a314/Software```
 - Set the build script as executable: ```sudo chmod +x rpi_docker_build.sh```


### PR DESCRIPTION
The build process does not require depencencies that do not come installed by default on Raspbian Lite.