### PR TITLE
Allow rename with same source and destination file in a314fs

### DIFF
--- a/Software/a314fs/a314fs.py
+++ b/Software/a314fs/a314fs.py
@@ -531,6 +531,10 @@ def process_rename_object(key, name, target_dir, new_name):
         return struct.pack('>HH', 0, ERROR_OBJECT_NOT_FOUND)
 
     to_path = '/'.join(cp2)
+
+    if from_path == to_path:
+        return struct.pack('>HH', 1, 0)
+
     if os.path.exists(to_path):
         return struct.pack('>HH', 0, ERROR_OBJECT_EXISTS)
 


### PR DESCRIPTION
Renaming a file to itself is allowed in AmigaDOS, so if the source and
destination paths are identical reply with success. Fixes #54