### PR TITLE
Fix error return for ACTION_FINDINPUT in a314fs

### DIFF
--- a/Software/a314fs/a314fs.py
+++ b/Software/a314fs/a314fs.py
@@ -418,7 +418,7 @@ def process_findxxx(mode, key, name):
 
     cp = find_path(key, name)
     if cp is None:
-        return struct.pack('>HH', 0, ERROR_DIR_NOT_FOUND)
+        return struct.pack('>HH', 0, ERROR_OBJECT_NOT_FOUND)
 
     path = '/'.join(cp)
     if len(cp) == 0 or os.path.isdir(path):


### PR DESCRIPTION
Using ACTION_FINDINPUT to check if a file exists wrongfully returned
ERROR_DIR_NOT_FOUND instead of ERROR_OBJECT_NOT_FOUND if the file was
searched for in a non-existent subdirectory.