### PR TITLE
Add ACTION_DISK_INFO and ACTION_INFO to a314fs

### DIFF
--- a/Software/a314fs/messages.h
+++ b/Software/a314fs/messages.h
@@ -280,6 +280,19 @@ struct SameLockResponse
 	short error_code;
 };
 
+struct InfoDataRequest
+{
+	short has_response;
+	short type;
+};
+
+struct InfoDataResponse
+{
+	short has_response;
+	long total;
+	long used;
+};
+
 struct ExamineFhRequest
 {
 	short has_response;


### PR DESCRIPTION
This update replaces the placeholder values for ACTION_DISK_INFO and ACTION_INFO with actual values from the Raspberry OS.
The values are then used by the Amiga OS to convey the amount of free and used space on the PiDisk device.