### PR TITLE
Add logging of unsupported a314fs actions

### DIFF
--- a/Software/a314fs/a314fs.py
+++ b/Software/a314fs/a314fs.py
@@ -144,6 +144,7 @@ ACTION_SEEK             = 1008
 ACTION_TRUNCATE         = 1022
 ACTION_WRITE_PROTECT    = 1023
 ACTION_EXAMINE_FH       = 1034
+ACTION_UNSUPPORTED      = 65535
 
 ERROR_NO_FREE_STORE             = 103
 ERROR_TASK_TABLE_FULL           = 105
@@ -650,7 +651,12 @@ def process_request(req):
     elif rtype == ACTION_SAME_LOCK:
         key1, key2 = struct.unpack('>II', req[2:10])
         return process_same_lock(key1, key2)
+    elif rtype == ACTION_UNSUPPORTED:
+        (dp_Type,) = struct.unpack('>H', req[2:4])
+        logger.warning('Unsupported action %d (Amiga/a314fs)', dp_Type)
+        return struct.pack('>HH', 0, ERROR_ACTION_NOT_KNOWN)
     else:
+        logger.warning('Unsupported action %d (a314d/a314fs)', rtype)
         return struct.pack('>HH', 0, ERROR_ACTION_NOT_KNOWN)
 
 done = False

--- a/Software/a314fs/messages.h
+++ b/Software/a314fs/messages.h
@@ -301,4 +301,18 @@ struct ExamineFhResponse
 	char file_name[1];
 };
 
+struct UnsupportedRequest
+{
+	short has_response;
+	short type;
+	short dp_Type;
+};
+
+struct UnsupportedResponse
+{
+	short has_response;
+	short success;
+	short error_code;
+};
+
 #pragma pack(pop)


### PR DESCRIPTION
Any filesystem action unsupported by a314fs on the Amiga or Linux will
now be logged in the Linux systemd journal as a warning for easier
debugging. Closes #53.