### PR TITLE
Add pip dependency to instructions

### DIFF
--- a/Software/README.md
+++ b/Software/README.md
@@ -8,7 +8,7 @@ On the Raspberry Pi do the following:
 - Install Raspbian: https://www.raspberrypi.org/downloads/raspbian/
 - Install Docker: ```curl -sSL https://get.docker.com | sh```
 - Allow user pi to run Docker: ```sudo usermod -aG docker pi```
-- Install Dependencies: ```sudo apt install python3-dev python3-distutils build-essential git```
+- Install Dependencies: ```sudo apt install python3-dev python3-distutils pip build-essential git```
 - Clone the a314 repo: ```git clone https://github.com/niklasekstrom/a314.git```
 - ```cd a314/Software```
 - Set the build script as executable: ```sudo chmod +x rpi_docker_build.sh```

--- a/Software/README.md
+++ b/Software/README.md
@@ -8,7 +8,7 @@ On the Raspberry Pi do the following:
 - Install Raspbian: https://www.raspberrypi.org/downloads/raspbian/
 - Install Docker: ```curl -sSL https://get.docker.com | sh```
 - Allow user pi to run Docker: ```sudo usermod -aG docker pi```
-- Install Dependencies: ```sudo apt install python3-dev python3-distutils pip build-essential git```
+- Install Dependencies: ```sudo apt install python3-dev python3-distutils python3-pip build-essential git```
 - Clone the a314 repo: ```git clone https://github.com/niklasekstrom/a314.git```
 - ```cd a314/Software```
 - Set the build script as executable: ```sudo chmod +x rpi_docker_build.sh```


### PR DESCRIPTION
Seems that `pip` is not installed together with `python3`.