### PR TITLE
WiP: picmd (with a314.device) works, but a314drive.device does not co…

### DIFF
--- a/Software/a314fs/a314fs.c
+++ b/Software/a314fs/a314fs.c
@@ -24,7 +24,9 @@
 
 #include "messages.h"
 
+#ifndef MKBADDR
 #define MKBADDR(x) (((ULONG)x) >> 2)
+#endif
 
 #define ID_314_DISK (('3' << 24) | ('1' << 16) | ('4' << 8))
 
@@ -297,7 +299,11 @@ LONG a314_reset()
 void create_and_add_volume()
 {
 	my_volume = (struct DeviceList *)DosAllocMem(sizeof(struct DeviceList));
+#ifdef LIBRARY_VERSION
 	my_volume->dl_Name = (BSTR*)MKBADDR(default_volume_name);
+#else
+	my_volume->dl_Name = (BSTR)MKBADDR(default_volume_name);
+#endif
 	my_volume->dl_Type = DLT_VOLUME;
 	my_volume->dl_Task = mp;
 	my_volume->dl_DiskType = ID_314_DISK;


### PR DESCRIPTION
There is still one missing component from NDK13 that is not supported (directly) by NDK32: 
```
>#include <libraries/romboot_base.h>
error 248 in line 17 of "disk/device.c": file 'libraries/romboot_base.h' not found
```