### PR TITLE
Update A314 installation to be user agnostic

### DIFF
--- a/Software/Makefile
+++ b/Software/Makefile
@@ -1,8 +1,38 @@
 .PHONY: bin_dir all
 
+ifndef VERBOSE
+.SILENT:
+endif
+
+A314_SERVICES        = a314d/a314d.py \
+                       a314fs/a314fs.py \
+                       picmd/picmd.py \
+                       piaudio/piaudio.py \
+                       remote-mouse/remote-mouse.py \
+                       hid/hid.py \
+                       ethernet/ethernet.py \
+                       disk/disk.py
+
+A314_SERVICE_CONFIGS = a314fs/a314fs.conf \
+                       picmd/picmd.conf \
+                       disk/disk.conf
+
+A314_PI_BINARIES     = ${BIN}/a314d \
+                       ${BIN}/start_gpclk
+
+
 CPP=g++
 CC=gcc
 BIN=bin_pi
+
+# Figure out the primary group and home directory of the user who used sudo
+SUDO_GROUP=$(shell getent group ${SUDO_GID} | cut -d: -f1)
+SUDO_HOME=$(shell awk -F':' -v U=${SUDO_USER} '$$1==U {print $$6}' /etc/passwd)
+
+# Replace some magic strings in files while installing to work with any username
+define modinstall
+	sed -e s%##USER##%${SUDO_USER}%g -e s%##GROUP##%${SUDO_GROUP}%g -e s%##HOME##%${SUDO_HOME}%g $(1) >$(2)/$(shell basename $(1))
+endef
 
 all: bin_dir ${BIN}/a314d ${BIN}/start_gpclk
 
@@ -10,30 +40,28 @@ bin_dir:
 	mkdir -p ${BIN}
 
 ${BIN}/a314d: a314d/a314d.cc
+	@echo "Building $@"
 	${CPP} a314d/a314d.cc -O3 -o ${BIN}/a314d
 
 ${BIN}/start_gpclk: a314d/start_gpclk.c
+	@echo "Building $@"
 	${CC} a314d/start_gpclk.c -I/opt/vc/include -L/opt/vc/lib -lbcm_host -o ${BIN}/start_gpclk
 
 install:
-	su -c "mkdir -p /home/pi/a314shared" pi
-	mkdir -p /opt/a314
-	cp ${BIN}/a314d /opt/a314
-	cp ${BIN}/start_gpclk /opt/a314
-	cp a314d/a314d.py /opt/a314
-	cp a314fs/a314fs.py /opt/a314
-	cp picmd/picmd.py /opt/a314
-	cp piaudio/piaudio.py /opt/a314
-	cp remote-mouse/remote-mouse.py /opt/a314
-	cp hid/hid.py /opt/a314
-	cp ethernet/ethernet.py /opt/a314
-	cp disk/disk.py /opt/a314
-	mkdir -p /etc/opt/a314
-	cp a314d/a314d.conf /etc/opt/a314
-	cp a314fs/a314fs.conf /etc/opt/a314
-	cp picmd/picmd.conf /etc/opt/a314
-	cp disk/disk.conf /etc/opt/a314
+ifneq ($(shell id -u), 0)
+	@echo "Please run the install using sudo"
+	@exit 1
+endif
+	@echo "Installing A314 files..."
+	install -d ${SUDO_HOME}/a314shared -o ${SUDO_USER} -g ${SUDO_GROUP}
+	install -d /opt/a314
+	install -d /etc/opt/a314
+	install ${A314_SERVICES} /opt/a314
+	install ${A314_PI_BINARIES} /opt/a314
+	install a314d/a314d.conf /etc/opt/a314
+	$(foreach filename, $(A314_SERVICE_CONFIGS), $(call modinstall, $(filename), /etc/opt/a314/);)
 	pip3 install pyudev
 	pip3 install python-pytun
-	cp ethernet/pi-config/tap0 /etc/network/interfaces.d
-	cp a314d/a314d.service /lib/systemd/system
+	install ethernet/pi-config/tap0 /etc/network/interfaces.d
+	$(call modinstall, a314d/a314d.service, /lib/systemd/system)
+	@echo "Installation completed!"

--- a/Software/a314d/a314d.service
+++ b/Software/a314d/a314d.service
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 Type=simple
-User=pi
-Group=pi
+User=##USER##
+Group=##GROUP##
 ExecStartPre=+/opt/a314/start_gpclk
 ExecStart=/opt/a314/a314d
 

--- a/Software/a314fs/a314fs.conf
+++ b/Software/a314fs/a314fs.conf
@@ -2,7 +2,7 @@
   "devices": {
     "PI0": {
       "volume": "PiDisk",
-      "path": "/home/pi/a314shared"
+      "path": "##HOME##/a314shared"
     }
   }
 }

--- a/Software/a314fs/a314fs.py
+++ b/Software/a314fs/a314fs.py
@@ -18,8 +18,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 CONFIG_FILE_PATH = '/etc/opt/a314/a314fs.conf'
-
-SHARED_DIRECTORY = '/home/pi/a314shared'
 METAFILE_EXTENSION = ':a314'
 
 with open(CONFIG_FILE_PATH, encoding='utf-8') as f:

--- a/Software/disk/disk.conf
+++ b/Software/disk/disk.conf
@@ -2,7 +2,7 @@
     "auto-insert": [
         {
             "unit": 0,
-            "filename": "/home/pi/a314shared/adfs/Workbench.adf",
+            "filename": "##HOME##/a314shared/adfs/Workbench.adf",
             "rw": false
         }
     ]

--- a/Software/picmd/picmd.conf
+++ b/Software/picmd/picmd.conf
@@ -1,7 +1,7 @@
 {
-  "paths": ["/home/pi/amiga_sdk/vbcc/bin"],
+  "paths": ["##HOME##/amiga_sdk/vbcc/bin"],
   "env_vars": {
-    "VBCC": "/home/pi/amiga_sdk/vbcc"
+    "VBCC": "##HOME##/amiga_sdk/vbcc"
   },
   "sgr_map": {
   }

--- a/Software/rpi_docker_build.sh
+++ b/Software/rpi_docker_build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 docker run --rm --volume "$PWD":/mnt --workdir /mnt -it niekstrom/a314-rpi-build:v2 make -f Makefile-amiga
-sudo chown -R pi:pi bin_amiga
+sudo chown -R $USER: bin_amiga


### PR DESCRIPTION
Can no longer count on there being a default 'pi' user to use in various hardcoded paths in A314. Update makefile to substitute with the installing users home directory etc.