### PR TITLE
Fix MyCreatePort to free allocated resources

### DIFF
--- a/Software/a314fs/a314fs.c
+++ b/Software/a314fs/a314fs.c
@@ -99,7 +99,14 @@ struct MsgPort *MyCreatePort(char *name, long pri)
 	port->mp_SigTask = FindTask(NULL);
 
 	if (name)
-		AddPort(port);
+	{
+		if (AddPort(port) == NULL)
+		{
+			FreeSignal(sigbit);
+			FreeMem(port, sizeof(struct MsgPort));
+			return NULL;
+		}
+	}
 	else
 		MyNewList(&(port->mp_MsgList));
 


### PR DESCRIPTION
 In some cases, the allocated resources (e.g., signal bits)
 are not properly freed before returning, which could lead to resource leaks.
 It's better to consistently free any allocated resources before returning in
 case of an error.
 These modifications ensure that any allocated resources are properly cleaned
 up in case of an error, preventing resource leaks.
 If the allocation of the signal bit fails, the function now immediately
 returns NULL without attempting to allocate the message port.

 If the allocation of the message port fails, the previously allocated signal
 bit is freed using FreeSignal before returning NULL.

 If adding the port to the system fails (when name is provided), the
 allocated signal bit is freed using FreeSignal, the allocated message port
 is freed using FreeMem, and the function returns NULL.