### PR TITLE
Remove traceback error if a command or file not found

### DIFF
--- a/Software/picmd/picmd.py
+++ b/Software/picmd/picmd.py
@@ -223,11 +223,11 @@ class PiCmdSession(object):
                     try:
                         os.execvp(args[0], args)
                     except FileNotFoundError:
-                        error_message = f"No such file or directory: {args[0]}\n"
+                        error_message = f'No such file or directory: {args[0]}\n'
                         os.write(sys.stderr.fileno(), error_message.encode('utf-8'))
                         os._exit(1)
                     except Exception as e:
-                        error_message = f"An error occurred: {str(e)}\n"
+                        error_message = f'An error occurred: {str(e)}\n'
                         os.write(sys.stderr.fileno(), error_message.encode('utf-8'))
                         os._exit(1)
 

--- a/Software/picmd/picmd.py
+++ b/Software/picmd/picmd.py
@@ -220,7 +220,16 @@ class PiCmdSession(object):
                         os.chdir(os.path.join(path, *components[1:]))
                     else:
                         os.chdir(os.getenv('HOME', '/'))
-                    os.execvp(args[0], args)
+                    try:
+                        os.execvp(args[0], args)
+                    except FileNotFoundError:
+                        error_message = f"No such file or directory: {args[0]}\n"
+                        os.write(sys.stderr.fileno(), error_message.encode('utf-8'))
+                        os._exit(1)
+                    except Exception as e:
+                        error_message = f"An error occurred: {str(e)}\n"
+                        os.write(sys.stderr.fileno(), error_message.encode('utf-8'))
+                        os._exit(1)
 
                 self.start_msg = None
 


### PR DESCRIPTION
When the Pi command on amiga can't find a command or file a traceback error was displayed, now it display only "No such file or directory: ..."