### PR TITLE
Add method to flash clock port version

### DIFF
--- a/Software/README.md
+++ b/Software/README.md
@@ -19,7 +19,7 @@ To build and install the software on the Raspberry Pi side, do the following:
   but any recent version should work):
   <https://www.raspberrypi.com/software/operating-systems/>
 - Update apt packages: `sudo apt update`, `sudo apt upgrade`
-- Install Dependencies: `sudo apt install python3-dev python3-distutils python3-pip python3-virtualenv build-essential git ifupdown iptables`
+- Install Dependencies: `sudo apt install python3-dev python3-distutils python3-pip python3-virtualenv build-essential git ifupdown iptables openfpgaloader`
 - Obtain a copy of the repository, either:
   - Clone the a314 repository: `git clone https://github.com/niklasekstrom/a314.git`, or
   - Download the sources from a release. Pick a release from
@@ -28,6 +28,7 @@ To build and install the software on the Raspberry Pi side, do the following:
 - Change into the Software directory: `cd a314/Software`
 - Run the installer script: `sudo ./install-pi.sh <model>`, where `<model>` is
   `td`, `cp` or `fe` depending on which variant of A314 is used.
+- For A314-cp users: Flash the latest CPLD firmware: `sudo ./install-pi.sh flash_cp`
 - Reboot the Raspberry Pi: `sudo reboot now`
 
 ### Amiga


### PR DESCRIPTION
Include action to fetch the latest firmware and flash it to the cpld. 

Example:
```
christian@amiga1200:~/a314/Software $ sudo ./install-pi.sh
Usage: sudo ./install-pi.sh <model|action>
       <model> is one of:
         td       (trapdoor)          A314-500, A314-600
         cp       (clockport)         A314-cp
         fe       (front expansion)   A314-1000
       <action> is one of:
         flash_cp (flash cpld)   Flash latest CPLD firmware

christian@a1200:~/a314/Software $ sudo ./install-pi.sh flash_cp
Fetching firmware
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 70267  100 70267    0     0  80911      0 --:--:-- --:--:-- --:--:-- 80911
Flashing CPLD
write to flash
Open file DONE
Erase flash DONE
Write Flash: [==================================================] 100.00%
Done
CPLD flashed successfully.
```