### PR TITLE
Add flash_cp action for flashing cpld on the cp version

### DIFF
--- a/Software/README.md
+++ b/Software/README.md
@@ -19,7 +19,7 @@ To build and install the software on the Raspberry Pi side, do the following:
   but any recent version should work):
   <https://www.raspberrypi.com/software/operating-systems/>
 - Update apt packages: `sudo apt update`, `sudo apt upgrade`
-- Install Dependencies: `sudo apt install python3-dev python3-distutils python3-pip python3-virtualenv build-essential git ifupdown iptables openfpgaloader`
+- Install Dependencies: `sudo apt install python3-dev python3-distutils python3-pip python3-virtualenv build-essential git ifupdown iptables`
 - Obtain a copy of the repository, either:
   - Clone the a314 repository: `git clone https://github.com/niklasekstrom/a314.git`, or
   - Download the sources from a release. Pick a release from
@@ -28,8 +28,15 @@ To build and install the software on the Raspberry Pi side, do the following:
 - Change into the Software directory: `cd a314/Software`
 - Run the installer script: `sudo ./install-pi.sh <model>`, where `<model>` is
   `td`, `cp` or `fe` depending on which variant of A314 is used.
-- For A314-cp users: Flash the latest CPLD firmware: `sudo ./install-pi.sh flash_cp`
 - Reboot the Raspberry Pi: `sudo reboot now`
+
+#### CPLD Flashing (A314-cp only)
+
+If you build the A314-cp hardware yourself, you might need to flash the CPLD
+with the latest firmware.
+
+- Install dependencies: `sudo apt install openfpgaloader`
+- Flash the latest firmware: `sudo ./flash-cpld.sh`
 
 ### Amiga
 

--- a/Software/flash-cpld.sh
+++ b/Software/flash-cpld.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+if [ `id -u` != 0 ] ; then
+	echo "Please run flash-cpld.sh using sudo (sudo ./flash-cpld.sh)"
+	exit 1
+fi
+
+flash_cp() {
+	if ! which openFPGALoader > /dev/null 2>&1; then
+		echo "Error: openFPGALoader is not installed"
+		exit 1
+	fi
+
+	RELEASE_INFO=$(curl -s https://api.github.com/repos/niklasekstrom/clockport_pi_interface/releases/latest)
+	JED_URL=$(echo "$RELEASE_INFO" | grep -o '"browser_download_url": "[^"]*cp_pi_if\.jed"' | cut -d'"' -f4)
+	
+	if [ -z "$JED_URL" ]; then
+		echo "Error: Could not find cp_pi_if.jed in latest release"
+		exit 1
+	fi
+
+  echo "Fetching firmware"
+	
+	TEMP_JED="/tmp/cp_pi_if.jed"
+	curl -L -o "$TEMP_JED" "$JED_URL"
+	
+	if [ ! -f "$TEMP_JED" ]; then
+		echo "Error: Failed to download CPLD firmware"
+		exit 1
+	fi
+
+  echo "Flashing CPLD"
+	
+	sudo openFPGALoader -c libgpiod --pins 10:8:11:9 -f "$TEMP_JED"
+  if [ $? -eq 0 ]; then
+      echo "CPLD flashed successfully."
+  else
+      echo "CPLD flashing failed or was interrupted."
+  fi	
+
+	rm -f "$TEMP_JED"
+}
+
+flash_cp

--- a/Software/install-pi.sh
+++ b/Software/install-pi.sh
@@ -156,42 +156,6 @@ install_frontexpansion() {
 	install_common
 }
 
-flash_cp() {
-	if ! which openFPGALoader > /dev/null 2>&1; then
-		echo "Error: openFPGALoader is not installed"
-		exit 1
-	fi
-
-	RELEASE_INFO=$(curl -s https://api.github.com/repos/niklasekstrom/clockport_pi_interface/releases/latest)
-	JED_URL=$(echo "$RELEASE_INFO" | grep -o '"browser_download_url": "[^"]*cp_pi_if\.jed"' | cut -d'"' -f4)
-	
-	if [ -z "$JED_URL" ]; then
-		echo "Error: Could not find cp_pi_if.jed in latest release"
-		exit 1
-	fi
-
-  echo "Fetching firmware"
-	
-	TEMP_JED="/tmp/cp_pi_if.jed"
-	curl -L -o "$TEMP_JED" "$JED_URL"
-	
-	if [ ! -f "$TEMP_JED" ]; then
-		echo "Error: Failed to download CPLD firmware"
-		exit 1
-	fi
-
-  echo "Flashing CPLD"
-	
-	sudo openFPGALoader -c libgpiod --pins 10:8:11:9 -f "$TEMP_JED"
-  if [ $? -eq 0 ]; then
-      echo "CPLD flashed successfully."
-  else
-      echo "CPLD flashing failed or was interrupted."
-  fi	
-
-	rm -f "$TEMP_JED"
-}
-
 case "$1" in
 	td | TD) install_trapdoor
 		;;
@@ -199,14 +163,10 @@ case "$1" in
 		;;
 	fe | FE) install_frontexpansion
 		;;
-	flash_cp) flash_cp
-		;;
-	*)	echo "Usage: sudo ./install-pi.sh <model|action>"
+	*)	echo "Usage: sudo ./install-pi.sh <model>"
 		echo "       <model> is one of:"
-		echo "         td       (trapdoor)          A314-500, A314-600"
-		echo "         cp       (clockport)         A314-cp"
-		echo "         fe       (front expansion)   A314-1000"
-		echo "       <action> is one of:"
-		echo "         flash_cp (flash cpld)   Flash latest CPLD firmware"
+		echo "         td   (trapdoor)          A314-500, A314-600"
+		echo "         cp   (clockport)         A314-cp"
+		echo "         fe   (front expansion)   A314-1000"
 		;;
 esac


### PR DESCRIPTION
Include action to fetch the latest firmware and flash it to the cpld. 

Example:
```
christian@amiga1200:~/a314/Software $ sudo ./install-pi.sh
Usage: sudo ./install-pi.sh <model|action>
       <model> is one of:
         td       (trapdoor)          A314-500, A314-600
         cp       (clockport)         A314-cp
         fe       (front expansion)   A314-1000
       <action> is one of:
         flash_cp (flash cpld)   Flash latest CPLD firmware

christian@a1200:~/a314/Software $ sudo ./install-pi.sh flash_cp
Fetching firmware
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 70267  100 70267    0     0  80911      0 --:--:-- --:--:-- --:--:-- 80911
Flashing CPLD
write to flash
Open file DONE
Erase flash DONE
Write Flash: [==================================================] 100.00%
Done
CPLD flashed successfully.
```