### PR TITLE
Update README.md

### DIFF
--- a/Software/README.md
+++ b/Software/README.md
@@ -19,7 +19,7 @@ To build and install the software on the Raspberry Pi side, do the following:
   but any recent version should work):
   <https://www.raspberrypi.com/software/operating-systems/>
 - Update apt packages: `sudo apt update`, `sudo apt upgrade`
-- Install Dependencies: `sudo apt install python3-dev python3-distutils python3-pip python3-virtualenv build-essential git ifupdown iptables`
+- Install Dependencies: `sudo apt install python3-dev python3-distutils python3-pip python3-virtualenv build-essential git ifupdown iptables libraspberrypi-dev`
 - Obtain a copy of the repository, either:
   - Clone the a314 repository: `git clone https://github.com/niklasekstrom/a314.git`, or
   - Download the sources from a release. Pick a release from


### PR DESCRIPTION
libraspberrypi-dev is needed for Pi OS Lite, it is not installed by default and thus bcm_host.h headers will not be on the system:

```
g++ -DMODEL_CP=1 a314d/a314d.cc -O3 -o bin_pi/a314d-cp gcc a314d/start_gpclk.c -I/opt/vc/include -L/opt/vc/lib -lbcm_host -o bin_pi/start_gpclk a314d/start_gpclk.c:13:10: fatal error: bcm_host.h: No such file or directory
   13 | #include <bcm_host.h>
      |          ^~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:27: bin_pi/start_gpclk] Error 1
install: cannot stat 'bin_pi/start_gpclk': No such file or directory
```