### PR TITLE
Add a314scsi.device (SCSI/RDB hdf images over A314)

### DIFF
--- a/Software/Makefile-amiga
+++ b/Software/Makefile-amiga
@@ -3,7 +3,7 @@
 VC=vc +kick13 -I${NDK32}/Include_H
 BIN=bin_amiga
 
-all: bin_dir ${BIN}/Devs/a314-td.device ${BIN}/Devs/a314-fe.device ${BIN}/Devs/a314-cp.device ${BIN}/L/a314fs ${BIN}/Devs/MountList ${BIN}/C/Pi ${BIN}/C/PiSetClock ${BIN}/C/PiAudio ${BIN}/C/RemoteMouse ${BIN}/C/PiHid ${BIN}/Devs/a314eth.device ${BIN}/Devs/a314disk.device ${BIN}/C/RemoteWB ${BIN}/C/VideoPlayer ${BIN}/C/DiagA314td
+all: bin_dir ${BIN}/Devs/a314-td.device ${BIN}/Devs/a314-fe.device ${BIN}/Devs/a314-cp.device ${BIN}/L/a314fs ${BIN}/Devs/MountList ${BIN}/C/Pi ${BIN}/C/PiSetClock ${BIN}/C/PiAudio ${BIN}/C/RemoteMouse ${BIN}/C/PiHid ${BIN}/Devs/a314eth.device ${BIN}/Devs/a314disk.device ${BIN}/Devs/a314scsi.device ${BIN}/C/RemoteWB ${BIN}/C/VideoPlayer ${BIN}/C/DiagA314td
 
 bin_dir:
 	mkdir -p ${BIN}
@@ -50,6 +50,9 @@ ${BIN}/Devs/a314eth.device: a314device/a314.h a314device/proto_a314.h ethernet/r
 
 ${BIN}/Devs/a314disk.device: a314device/a314.h a314device/proto_a314.h disk/romtag.asm disk/device.c disk/debug.h disk/debug.c
 	${VC} disk/romtag.asm disk/device.c disk/debug.c -O3 -nostdlib -o ${BIN}/Devs/a314disk.device -lamiga
+
+${BIN}/Devs/a314scsi.device: a314device/a314.h a314device/proto_a314.h scsi/romtag.asm scsi/device.c scsi/scsicmd.c scsi/a314hw.c scsi/rdb.c scsi/lseg.c scsi/cli.c scsi/alib.c scsi/kprintf.c scsi/a314scsi.h scsi/a314scsi_protocol.h scsi/scsi.h scsi/alib.h scsi/kprintf.h
+	${VC} scsi/romtag.asm scsi/device.c scsi/scsicmd.c scsi/a314hw.c scsi/rdb.c scsi/lseg.c scsi/cli.c scsi/alib.c scsi/kprintf.c -O1 -nostdlib -o ${BIN}/Devs/a314scsi.device -lamiga
 
 ${BIN}/C/RemoteWB: a314device/a314.h a314device/proto_a314.h remotewb/remotewb.c remotewb/vblank_server.asm
 	${VC} remotewb/remotewb.c remotewb/vblank_server.asm -lamiga -o ${BIN}/C/RemoteWB

--- a/Software/a314d/a314d.conf
+++ b/Software/a314d/a314d.conf
@@ -6,4 +6,5 @@ remote-mouse	/opt/a314/venv/bin/python3	/opt/a314/remote-mouse.py
 videoplayer	/opt/a314/venv/bin/python3	/opt/a314/videoplayer.py
 ethernet	/opt/a314/venv/bin/python3	/opt/a314/ethernet.py
 disk		/opt/a314/venv/bin/python3	/opt/a314/disk.py
+scsi		/opt/a314/venv/bin/python3	/opt/a314/scsi.py
 hid		/opt/a314/venv/bin/python3	/opt/a314/hid.py

--- a/Software/install-pi.sh
+++ b/Software/install-pi.sh
@@ -22,6 +22,7 @@ install_common() {
 	install piaudio/piaudio.py /opt/a314
 	install remotewb/remotewb.py /opt/a314
 	install disk/disk.py /opt/a314
+	install scsi/scsi.py /opt/a314
 	install ethernet/ethernet.py /opt/a314
 	install hid/hid.py /opt/a314
 	install remote-mouse/remote-mouse.py /opt/a314
@@ -32,6 +33,7 @@ install_common() {
 	[ -f /etc/opt/a314/picmd.conf ] || modinstall picmd/picmd.conf /etc/opt/a314
 	[ -f /etc/opt/a314/a314fs.conf ] || modinstall a314fs/a314fs.conf /etc/opt/a314
 	[ -f /etc/opt/a314/disk.conf ] || modinstall disk/disk.conf /etc/opt/a314
+	[ -f /etc/opt/a314/scsi.conf ] || modinstall scsi/scsi.conf /etc/opt/a314
 
 	# Add shared directory for a314fs
 	sudo -u $A314_USER mkdir -p ${A314_HOME}/a314shared

--- a/Software/scsi/a314hw.c
+++ b/Software/scsi/a314hw.c
@@ -212,8 +212,14 @@ LONG a314_scsi(struct A314ScsiBase* base, struct Drive* d, struct SCSICmd* cmd)
         return err;
     }
 
+    if (res.kind != A314SCSI_CMD_RES)
+    {
+        kprintf("a314scsi: bad res kind=%ld\n", (ULONG)res.kind);
+        return IOERR_ABORTED;
+    }
+
     cmd->scsi_Status = res.scsi_status;
-    cmd->scsi_Actual = res.actual_length;
+    cmd->scsi_Actual = (res.actual_length > cmd->scsi_Length) ? cmd->scsi_Length : res.actual_length;
 
     if (dir == A314SCSI_DIR_READ && bounced && res.actual_length)
     {

--- a/Software/scsi/a314hw.c
+++ b/Software/scsi/a314hw.c
@@ -1,0 +1,244 @@
+#include <exec/types.h>
+#include <exec/memory.h>
+#include <exec/io.h>
+#include <exec/errors.h>
+
+#include <dos/dos.h> // TICKS_PER_SECOND
+
+#include <devices/timer.h>
+#include <devices/scsidisk.h>
+
+#include <proto/exec.h>
+
+
+#include <string.h>
+
+#include "../a314device/a314.h"
+#include "../a314device/proto_a314.h"
+
+#include "a314scsi.h"
+#include "a314scsi_protocol.h"
+#include "scsi.h"
+#include "alib.h"
+#include "kprintf.h"
+
+#define SysBase (*(struct ExecBase**)4)
+
+// Redirect the proto_a314.h helper macros to the per-device library base.
+#undef A314Base
+#define A314Base (base->a314base)
+
+static const char service_name[] = "scsi";
+static const char a314_name[] = A314_NAME;
+
+static ULONG get_socket_id(void)
+{
+    struct timerequest tr;
+
+    memset(&tr, 0, sizeof(tr));
+    tr.tr_node.io_Message.mn_Node.ln_Type = NT_REPLYMSG;
+
+    if (OpenDevice((STRPTR)TIMERNAME, UNIT_VBLANK, (struct IORequest*)&tr, 0))
+    {
+        return 0x53435349UL; // 'SCSI'
+    }
+
+    tr.tr_node.io_Command = TR_GETSYSTIME;
+    DoIO((struct IORequest*)&tr);
+    CloseDevice((struct IORequest*)&tr);
+
+    return (tr.tr_time.tv_secs * TICKS_PER_SECOND) ^ 0x53435349UL;
+}
+
+// Open a314.device and reserve resources. This MUST run in init_device's caller
+// context (a normal process), NOT the freshly-created io task: opening the device
+// from a just-added task races with a314.device's own startup and hangs.
+BOOL a314_open_device(struct A314ScsiBase* base)
+{
+    // OpenDevice needs a reply port, but the io task owns the real one; use a
+    // throwaway port here and let a314_connect() install the io task's port.
+    struct MsgPort* tmp = CreatePort(NULL, 0);
+    if (!tmp)
+    {
+        return FALSE;
+    }
+
+    memset(&base->a314ior, 0, sizeof(base->a314ior));
+    base->a314ior.a314_Request.io_Message.mn_ReplyPort = tmp;
+    base->a314ior.a314_Request.io_Message.mn_Length = sizeof(base->a314ior);
+
+    if (OpenDevice((STRPTR)a314_name, 0, &base->a314ior.a314_Request, 0))
+    {
+        kprintf("a314scsi: OpenDevice(a314.device) FAILED\n");
+        DeletePort(tmp);
+        return FALSE;
+    }
+    base->a314base = &base->a314ior.a314_Request.io_Device->dd_Library;
+
+    DeletePort(tmp);
+
+    base->socket = get_socket_id();
+
+    base->bounce = AllocMemA314(A314SCSI_MAX_XFER);
+    if (base->bounce == INVALID_A314_ADDRESS)
+    {
+        kprintf("a314scsi: AllocMemA314 FAILED\n");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+// Connect to the host 'scsi' service. Runs in the io task, which owns the reply
+// port used for this and every subsequent A314_WRITE/READ transaction.
+BOOL a314_connect(struct A314ScsiBase* base)
+{
+    base->a314port = CreatePort(NULL, 0);
+    if (!base->a314port)
+    {
+        return FALSE;
+    }
+
+    base->a314ior.a314_Request.io_Message.mn_ReplyPort = base->a314port;
+
+    base->a314ior.a314_Request.io_Command = A314_CONNECT;
+    base->a314ior.a314_Request.io_Error = 0;
+    base->a314ior.a314_Socket = base->socket;
+    base->a314ior.a314_Buffer = (STRPTR)service_name;
+    base->a314ior.a314_Length = strlen(service_name);
+    DoIO(&base->a314ior.a314_Request);
+
+    if (base->a314ior.a314_Request.io_Error != A314_CONNECT_OK)
+    {
+        kprintf("a314scsi: CONNECT failed err=%ld\n", (ULONG)base->a314ior.a314_Request.io_Error);
+        return FALSE;
+    }
+
+    base->connected = 1;
+    kprintf("a314scsi: connected to 'scsi' (socket=%lx)\n", base->socket);
+    return TRUE;
+}
+
+static LONG a314_txn(struct A314ScsiBase* base, struct A314ScsiReq* req, struct A314ScsiRes* res)
+{
+    base->a314ior.a314_Request.io_Command = A314_WRITE;
+    base->a314ior.a314_Request.io_Error = 0;
+    base->a314ior.a314_Socket = base->socket;
+    base->a314ior.a314_Buffer = (STRPTR)req;
+    base->a314ior.a314_Length = sizeof(struct A314ScsiReq);
+    DoIO(&base->a314ior.a314_Request);
+    if (base->a314ior.a314_Request.io_Error != A314_WRITE_OK)
+    {
+        return IOERR_ABORTED;
+    }
+
+    base->a314ior.a314_Request.io_Command = A314_READ;
+    base->a314ior.a314_Request.io_Error = 0;
+    base->a314ior.a314_Socket = base->socket;
+    base->a314ior.a314_Buffer = (STRPTR)res;
+    base->a314ior.a314_Length = sizeof(struct A314ScsiRes);
+    DoIO(&base->a314ior.a314_Request);
+    if (base->a314ior.a314_Request.io_Error != A314_READ_OK)
+    {
+        return IOERR_ABORTED;
+    }
+
+    return 0;
+}
+
+LONG a314_scsi(struct A314ScsiBase* base, struct Drive* d, struct SCSICmd* cmd)
+{
+    struct A314ScsiReq req;
+    struct A314ScsiRes res;
+
+    if (!base->connected)
+    {
+        return IOERR_ABORTED;
+    }
+
+    if (cmd->scsi_Length > A314SCSI_MAX_XFER)
+    {
+        return IOERR_ABORTED; // caller must chunk
+    }
+
+    UBYTE dir;
+    if (cmd->scsi_Length == 0)
+    {
+        dir = A314SCSI_DIR_NONE;
+    }
+    else if (cmd->scsi_Flags & SCSIF_READ)
+    {
+        dir = A314SCSI_DIR_READ;
+    }
+    else
+    {
+        dir = A314SCSI_DIR_WRITE;
+    }
+
+    // Resolve the a314-space address of the caller buffer, else use the bounce.
+    ULONG addr = 0;
+    BOOL bounced = FALSE;
+    if (cmd->scsi_Length)
+    {
+        addr = TranslateAddressA314((APTR)cmd->scsi_Data);
+        if (addr == INVALID_A314_ADDRESS)
+        {
+            addr = base->bounce;
+            bounced = TRUE;
+            if (dir == A314SCSI_DIR_WRITE)
+            {
+                WriteMemA314(base->bounce, (APTR)cmd->scsi_Data, cmd->scsi_Length);
+            }
+        }
+    }
+
+    memset(&req, 0, sizeof(req));
+    req.kind = A314SCSI_CMD_REQ;
+    req.unit = d ? (UBYTE)d->number : 0;
+    req.cdb_len = (UBYTE)cmd->scsi_CmdLength;
+    if (req.cdb_len > A314SCSI_MAX_CDB)
+    {
+        req.cdb_len = A314SCSI_MAX_CDB;
+    }
+    memcpy(req.cdb, cmd->scsi_Command, req.cdb_len);
+    req.direction = dir;
+    req.data_length = cmd->scsi_Length;
+    req.address = addr;
+
+    LONG err = a314_txn(base, &req, &res);
+    if (err)
+    {
+        kprintf("a314scsi: txn err=%ld\n", err);
+        return err;
+    }
+
+    cmd->scsi_Status = res.scsi_status;
+    cmd->scsi_Actual = res.actual_length;
+
+    if (dir == A314SCSI_DIR_READ && bounced && res.actual_length)
+    {
+        ULONG n = res.actual_length;
+        if (n > cmd->scsi_Length)
+        {
+            n = cmd->scsi_Length;
+        }
+        ReadMemA314((APTR)cmd->scsi_Data, base->bounce, n);
+    }
+
+    if (res.scsi_status != SCSI_STATUS_GOOD)
+    {
+        if (cmd->scsi_SenseData && cmd->scsi_SenseLength >= 14)
+        {
+            memset(cmd->scsi_SenseData, 0, cmd->scsi_SenseLength);
+            cmd->scsi_SenseData[0] = SCSI_SENSE_CURRENT_FIXED;
+            cmd->scsi_SenseData[2] = res.sense_key;
+            cmd->scsi_SenseData[7] = SCSI_SENSE_ADD_LEN;
+            cmd->scsi_SenseData[12] = res.asc;
+            cmd->scsi_SenseData[13] = res.ascq;
+            cmd->scsi_SenseActual = 14;
+        }
+        return HFERR_BadStatus;
+    }
+
+    return 0;
+}

--- a/Software/scsi/a314scsi.h
+++ b/Software/scsi/a314scsi.h
@@ -1,0 +1,103 @@
+#ifndef A314SCSI_H
+#define A314SCSI_H
+
+#include <exec/types.h>
+#include <exec/devices.h>
+#include <exec/io.h>
+#include <exec/ports.h>
+#include <exec/tasks.h>
+#include <exec/lists.h>
+#include <exec/libraries.h>
+
+#include <dos/dos.h> // BPTR
+
+#include <devices/scsidisk.h> // struct SCSICmd
+
+#include "../a314device/a314.h" // struct A314_IORequest
+
+#define DEVICE_NAME "a314scsi.device"
+#define DEVICE_VERSION 1
+#define DEVICE_REVISION 0
+
+// How many drive units the host can serve (unit number -> HDF).
+#define A314SCSI_MAX_DRIVES 4
+
+// Amiga unit numbering follows the scsi.device convention: unit = LUN*10 + ID.
+// Each host disk is exposed as its own LUN (ID 0), so valid units are 0, 10,
+// 20, ... - which is exactly what HDToolBox probes.
+#define A314SCSI_UNIT_STEP 10
+
+#define TASK_PRIORITY 10
+#define TASK_STACK_SIZE 4096
+
+// Largest single a314 transfer == the a314-memory bounce buffer.
+#define A314SCSI_MAX_XFER (4UL * 1024)
+
+// Drive flags.
+#define DRVF_PRESENT (1 << 0)
+#define DRVF_WRITEPROT (1 << 1)
+#define DRVF_REMOVABLE (1 << 2)
+#define DRVF_MOUNTED (1 << 3)
+
+struct Drive
+{
+    UWORD           number;         // unit number
+    UWORD           opencount;
+    UWORD           flags;          // DRVF_*
+    UBYTE           devtype;        // INQUIRY peripheral device type
+    UBYTE           blockshift;     // log2(blocksize)
+    ULONG           blocksize;
+    ULONG           blocks;         // total block count
+    UBYTE           sense[24];      // last auto/request sense
+};
+
+struct A314ScsiBase
+{
+    struct Device           device;
+    struct ExecBase*        sysbase;
+    BPTR                    seglist;
+
+    struct Drive*           drives[A314SCSI_MAX_DRIVES];
+
+    struct MsgPort*         reqport;        // command queue to the io task
+    struct Task             iotask;         // embedded io task (tc_UserData -> base)
+    APTR                    stack;
+
+    // a314 transport (opened and used only by the io task)
+    struct MsgPort*         a314port;
+    struct A314_IORequest   a314ior;
+    struct Library*         a314base;
+    ULONG                   socket;
+    ULONG                   bounce;         // a314-space bounce buffer
+    UBYTE                   connected;
+
+    // io-task startup handshake back to init_device
+    struct Task*            inittask;
+    ULONG                   initsig;
+    volatile UBYTE          started;
+};
+
+// device.c
+extern const char device_name[];
+struct Drive* find_drive(struct A314ScsiBase* base, UWORD number);
+struct Drive* make_drive(struct A314ScsiBase* base, UWORD number);
+
+// scsicmd.c
+LONG scsi_test_ready(struct A314ScsiBase* base, struct Drive* d);
+LONG scsi_inquiry(struct A314ScsiBase* base, struct Drive* d);
+LONG scsi_read_capacity(struct A314ScsiBase* base, struct Drive* d);
+LONG scsi_mode_sense_wp(struct A314ScsiBase* base, struct Drive* d);
+LONG scsi_rw(struct A314ScsiBase* base, struct Drive* d, ULONG lba, ULONG blocks, APTR buf, BOOL write);
+
+// a314hw.c
+BOOL a314_open_device(struct A314ScsiBase* base);
+BOOL a314_connect(struct A314ScsiBase* base);
+LONG a314_scsi(struct A314ScsiBase* base, struct Drive* d, struct SCSICmd* cmd);
+
+// rdb.c
+void mount_drive(struct A314ScsiBase* base, struct Drive* d);
+
+// lseg.c
+BPTR load_seglist(struct A314ScsiBase* base, struct Drive* d, ULONG first_block);
+
+#endif

--- a/Software/scsi/a314scsi_protocol.h
+++ b/Software/scsi/a314scsi_protocol.h
@@ -1,0 +1,59 @@
+#ifndef A314SCSI_PROTOCOL_H
+#define A314SCSI_PROTOCOL_H
+
+#include <exec/types.h>
+
+// Wire protocol between a314scsi.device (Amiga) and the host "scsi" service.
+//
+// A SCSI CDB is tunneled to the host; bulk data is NOT inlined but moved
+// through a314 shared memory at 'address' (an a314-space address).
+//
+// Python struct formats (host side):
+//   request : ">BBBB16sBBHII"  (32 bytes)
+//   response: ">BBBBBBHI"      (12 bytes)
+
+#define A314SCSI_CMD_REQ    1   // Amiga -> host
+#define A314SCSI_CMD_RES    2   // host  -> Amiga
+
+#define A314SCSI_DIR_NONE   0
+#define A314SCSI_DIR_READ   1   // device -> host: host writes data into a314 mem
+#define A314SCSI_DIR_WRITE  2   // host -> device: host reads data out of a314 mem
+
+#define A314SCSI_MAX_CDB 16
+
+#pragma pack(push, 1)
+
+struct A314ScsiReq
+{
+    UBYTE kind;                  // A314SCSI_CMD_REQ         @0
+    UBYTE unit;                  // drive/unit number        @1
+    UBYTE cdb_len;               // 6/10/12/16               @2
+    UBYTE reserved0;             //                          @3
+    UBYTE cdb[A314SCSI_MAX_CDB]; //                          @4
+    UBYTE direction;             // A314SCSI_DIR_*           @20
+    UBYTE pad;                   //                          @21
+    UWORD reserved1;             //                          @22
+    ULONG data_length;           // expected transfer bytes  @24
+    ULONG address;               // a314-space data address  @28
+}; // sizeof == 32
+
+struct A314ScsiRes
+{
+    UBYTE kind;          // A314SCSI_CMD_RES           @0
+    UBYTE scsi_status;   // 0=GOOD, 2=CHECK CONDITION  @1
+    UBYTE sense_key;     //                            @2
+    UBYTE asc;           //                            @3
+    UBYTE ascq;          //                            @4
+    UBYTE pad;           //                            @5
+    UWORD reserved;      //                            @6
+    ULONG actual_length; //                            @8
+}; // sizeof == 12
+
+#pragma pack(pop)
+
+// SCSI status byte values.
+#define SCSI_STATUS_GOOD            0x00
+#define SCSI_STATUS_CHECK_CONDITION 0x02
+#define SCSI_STATUS_BUSY            0x08
+
+#endif

--- a/Software/scsi/alib.c
+++ b/Software/scsi/alib.c
@@ -1,0 +1,59 @@
+#include <exec/types.h>
+#include <exec/memory.h>
+#include <exec/lists.h>
+#include <exec/nodes.h>
+#include <exec/ports.h>
+
+#include <proto/exec.h>
+
+#include <string.h>
+
+#include "alib.h"
+
+#define SysBase (*(struct ExecBase**)4)
+
+void NewList(struct List* list)
+{
+    list->lh_Head = (struct Node*)&list->lh_Tail;
+    list->lh_Tail = NULL;
+    list->lh_TailPred = (struct Node*)&list->lh_Head;
+}
+
+struct MsgPort* CreatePort(STRPTR name, LONG pri)
+{
+    BYTE sig = AllocSignal(-1);
+    if (sig == -1)
+        return NULL;
+
+    struct MsgPort* port = (struct MsgPort*)AllocMem(sizeof(struct MsgPort), MEMF_PUBLIC | MEMF_CLEAR);
+    if (!port)
+    {
+        FreeSignal(sig);
+        return NULL;
+    }
+
+    port->mp_Node.ln_Name = (char*)name;
+    port->mp_Node.ln_Pri = (BYTE)pri;
+    port->mp_Node.ln_Type = NT_MSGPORT;
+    port->mp_Flags = PA_SIGNAL;
+    port->mp_SigBit = sig;
+    port->mp_SigTask = FindTask(NULL);
+    NewList(&port->mp_MsgList);
+
+    if (name)
+        AddPort(port);
+
+    return port;
+}
+
+void DeletePort(struct MsgPort* port)
+{
+    if (!port)
+        return;
+
+    if (port->mp_Node.ln_Name)
+        RemPort(port);
+
+    FreeSignal(port->mp_SigBit);
+    FreeMem(port, sizeof(struct MsgPort));
+}

--- a/Software/scsi/alib.h
+++ b/Software/scsi/alib.h
@@ -1,0 +1,12 @@
+#ifndef ALIB_H
+#define ALIB_H
+
+#include <exec/types.h>
+#include <exec/lists.h>
+#include <exec/ports.h>
+
+void NewList(struct List* list);
+struct MsgPort* CreatePort(STRPTR name, LONG pri);
+void DeletePort(struct MsgPort* port);
+
+#endif

--- a/Software/scsi/cli.c
+++ b/Software/scsi/cli.c
@@ -1,0 +1,128 @@
+#include <exec/types.h>
+#include <exec/memory.h>
+#include <exec/io.h>
+#include <exec/nodes.h>
+#include <exec/lists.h>
+
+#include <libraries/dos.h>
+#include <libraries/dosextens.h>
+#include <libraries/filehandler.h>
+#include <libraries/expansion.h>
+#include <libraries/expansionbase.h>
+
+#include <proto/exec.h>
+#include <proto/expansion.h>
+
+#include <string.h>
+
+#include "a314scsi.h"
+#include "alib.h"
+#include "kprintf.h"
+
+#define SysBase (*(struct ExecBase**)4)
+
+#define MAX_PENDING 16
+
+// Is this DeviceNode one of ours (its exec device name == a314scsi.device)?
+static BOOL is_ours(struct DeviceNode* dn)
+{
+    if (!dn || !dn->dn_Startup)
+    {
+        return FALSE;
+    }
+
+    struct FileSysStartupMsg* fssm = (struct FileSysStartupMsg*)BADDR(dn->dn_Startup);
+    if (!fssm->fssm_Device)
+    {
+        return FALSE;
+    }
+
+    const UBYTE* name = (const UBYTE*)BADDR(fssm->fssm_Device);
+    UBYTE len = (UBYTE)strlen(DEVICE_NAME);
+    return name[0] == len && memcmp(&name[1], DEVICE_NAME, len) == 0;
+}
+
+int memcmp(const void* a, const void* b, size_t n)
+{
+    const UBYTE* pa = (const UBYTE*)a;
+    const UBYTE* pb = (const UBYTE*)b;
+    for (size_t i = 0; i < n; i++)
+    {
+        if (pa[i] != pb[i])
+        {
+            return (int)pa[i] - (int)pb[i];
+        }
+    }
+    return 0;
+}
+
+LONG cli_main(void)
+{
+    kprintf("a314scsi: cli enter\n");
+    struct Library* ExpansionBase = OpenLibrary((STRPTR)EXPANSIONNAME, 0);
+    if (!ExpansionBase)
+    {
+        return RETURN_FAIL;
+    }
+
+    struct MsgPort* port = CreatePort(NULL, 0);
+    if (!port)
+    {
+        CloseLibrary(ExpansionBase);
+        return RETURN_FAIL;
+    }
+
+    // Opening the device runs its io task, which discovers and enqueues the
+    // partitions. If it wasn't resident yet this also loads it.
+    struct IOStdReq ior;
+    memset(&ior, 0, sizeof(ior));
+    ior.io_Message.mn_ReplyPort = port;
+    ior.io_Message.mn_Length = sizeof(ior);
+
+    if (OpenDevice((STRPTR)DEVICE_NAME, 0, (struct IORequest*)&ior, 0))
+    {
+        kprintf("a314scsi: cli OpenDevice FAILED\n");
+        DeletePort(port);
+        CloseLibrary(ExpansionBase);
+        return RETURN_FAIL;
+    }
+
+    // Detach our BootNodes from the MountList under Forbid, then AddDosNode them
+    // outside it (AddDosNode with ADNF_STARTPROC creates a process). Removing
+    // them makes repeated runs idempotent.
+    struct DeviceNode* pending[MAX_PENDING];
+    LONG pri[MAX_PENDING];
+    UWORD count = 0;
+
+    struct List* ml = &((struct ExpansionBase*)ExpansionBase)->MountList;
+
+    Forbid();
+    struct Node* n = ml->lh_Head;
+    while (n->ln_Succ && count < MAX_PENDING)
+    {
+        struct Node* next = n->ln_Succ;
+        struct BootNode* bn = (struct BootNode*)n;
+        if (is_ours((struct DeviceNode*)bn->bn_DeviceNode))
+        {
+            Remove(n);
+            pending[count] = (struct DeviceNode*)bn->bn_DeviceNode;
+            pri[count] = (LONG)(BYTE)bn->bn_Node.ln_Pri;
+            count++;
+        }
+        n = next;
+    }
+    Permit();
+
+    for (UWORD i = 0; i < count; i++)
+    {
+        kprintf("a314scsi: cli AddDosNode pri=%ld\n", pri[i]);
+        AddDosNode(pri[i], ADNF_STARTPROC, pending[i]);
+    }
+
+    CloseDevice((struct IORequest*)&ior);
+    DeletePort(port);
+    CloseLibrary(ExpansionBase);
+
+    kprintf("a314scsi: cli mounted %ld node(s)\n", (LONG)count);
+    return RETURN_OK;
+}

--- a/Software/scsi/cli.c
+++ b/Software/scsi/cli.c
@@ -79,7 +79,16 @@ LONG cli_main(void)
     ior.io_Message.mn_ReplyPort = port;
     ior.io_Message.mn_Length = sizeof(ior);
 
-    if (OpenDevice((STRPTR)DEVICE_NAME, 0, (struct IORequest*)&ior, 0))
+    BOOL opened = FALSE;
+    for (UWORD u = 0; u < A314SCSI_MAX_DRIVES; u++)
+    {
+        if (!OpenDevice((STRPTR)DEVICE_NAME, u * A314SCSI_UNIT_STEP, (struct IORequest*)&ior, 0))
+        {
+            opened = TRUE;
+            break;
+        }
+    }
+    if (!opened)
     {
         kprintf("a314scsi: cli OpenDevice FAILED\n");
         DeletePort(port);

--- a/Software/scsi/device.c
+++ b/Software/scsi/device.c
@@ -1,0 +1,554 @@
+#include <exec/types.h>
+#include <exec/execbase.h>
+#include <exec/memory.h>
+#include <exec/errors.h>
+#include <exec/io.h>
+
+#include <devices/trackdisk.h>
+#include <devices/newstyle.h>
+#include <devices/scsidisk.h>
+
+#include <dos/dos.h>
+
+#include <proto/exec.h>
+
+#include <string.h>
+
+#include "a314scsi.h"
+#include "scsi.h"
+#include "alib.h"
+#include "kprintf.h"
+
+#define SysBase (*(struct ExecBase**)4)
+
+extern void task_body(void);
+
+const char device_name[] = DEVICE_NAME;
+const char id_string[] = DEVICE_NAME " 1.0 (9.9.2025)";
+
+// ---------------------------------------------------------------------------
+// Drive lookup / discovery
+// ---------------------------------------------------------------------------
+
+struct Drive* find_drive(struct A314ScsiBase* base, UWORD number)
+{
+    if (number >= A314SCSI_MAX_DRIVES)
+    {
+        return NULL;
+    }
+    return base->drives[number];
+}
+
+static BOOL discover_drive(struct A314ScsiBase* base, struct Drive* d)
+{
+    kprintf("a314scsi: discover unit %ld\n", (ULONG)d->number);
+
+    if (scsi_inquiry(base, d) != 0)
+    {
+        kprintf("a314scsi: INQUIRY failed\n");
+        return FALSE;
+    }
+
+    kprintf("a314scsi: INQUIRY type=%ld\n", (ULONG)d->devtype);
+
+    // A few TEST UNIT READY tries in case the medium needs a moment;
+    // the a314 round-trip itself paces the retries.
+    for (int i = 0; i < 5; i++)
+    {
+        if (scsi_test_ready(base, d) == 0)
+        {
+            break;
+        }
+    }
+
+    if (scsi_read_capacity(base, d) != 0)
+    {
+        kprintf("a314scsi: READ CAPACITY failed\n");
+        return FALSE;
+    }
+
+    scsi_mode_sense_wp(base, d);
+
+    d->flags |= DRVF_PRESENT;
+
+    kprintf("a314scsi: unit %ld blocks=%ld bs=%ld\n", (ULONG)d->number, d->blocks, d->blocksize);
+
+    return TRUE;
+}
+
+struct Drive* make_drive(struct A314ScsiBase* base, UWORD number)
+{
+    if (number >= A314SCSI_MAX_DRIVES)
+        return NULL;
+
+    if (base->drives[number])
+        return base->drives[number];
+
+    struct Drive* d = (struct Drive*)AllocMem(sizeof(struct Drive), MEMF_PUBLIC | MEMF_CLEAR);
+    if (!d)
+        return NULL;
+
+    d->number = number;
+    d->blocksize = 512;
+    d->blockshift = 9;
+
+    base->drives[number] = d;
+
+    if (!discover_drive(base, d))
+    {
+        base->drives[number] = NULL;
+        FreeMem(d, sizeof(struct Drive));
+        return NULL;
+    }
+
+    return d;
+}
+
+// ---------------------------------------------------------------------------
+// Command handling (io task context)
+// ---------------------------------------------------------------------------
+
+static LONG map_error(struct Drive* d, LONG err)
+{
+    if (err == 0)
+        return 0;
+
+    // Transport failures carry no sense data; pass them through unchanged.
+    if (err != HFERR_BadStatus)
+        return err;
+
+    // Refine a CHECK CONDITION into a specific reason via the sense key that
+    // a314_scsi captured in d->sense - so filesystems see write-protect,
+    // not-ready, etc. instead of a generic error.
+    switch (d->sense[2] & SCSI_SENSE_KEY_MASK)
+    {
+        case SCSI_SK_DATA_PROTECT:   return TDERR_WriteProt;
+        case SCSI_SK_NOT_READY:      return TDERR_DiskChanged;
+        case SCSI_SK_UNIT_ATTENTION: return TDERR_DiskChanged;
+        case SCSI_SK_HARDWARE_ERROR: return HFERR_BadStatus;
+        default:                     return TDERR_NotSpecified;
+    }
+}
+
+static void do_read_write(struct A314ScsiBase* base, struct Drive* d, struct IOStdReq* ior, BOOL write)
+{
+    UWORD shift = d->blockshift;
+    ULONG cmd = ior->io_Command;
+
+    ULONG off_lo = ior->io_Offset;
+    ULONG off_hi = 0;
+    if (cmd == TD_READ64        || 
+        cmd == TD_WRITE64       || 
+        cmd == NSCMD_TD_READ64  || 
+        cmd == NSCMD_TD_WRITE64 )
+    {
+        off_hi = ior->io_Actual; // TD64: high 32 bits of the byte offset
+    }
+
+    // Byte offset (off_hi:off_lo) -> 32-bit LBA in block units (<= 2 TB).
+    ULONG lba = (off_lo >> shift) | (shift ? (off_hi << (32 - shift)) : 0);
+    ULONG blocks = ior->io_Length >> shift;
+
+    UBYTE* buf = (UBYTE*)ior->io_Data;
+    ULONG max_blocks = A314SCSI_MAX_XFER >> shift;
+    LONG err = 0;
+
+    while (blocks > 0 && err == 0)
+    {
+        ULONG n = (blocks > max_blocks) ? max_blocks : blocks;
+
+        err = scsi_rw(base, d, lba, n, buf, write);
+
+        buf += (n << shift);
+        blocks -= n;
+        lba += n;
+    }
+
+    ior->io_Actual = err ? 0 : ior->io_Length;
+    ior->io_Error = map_error(d, err);
+}
+
+static void get_geometry(struct Drive* d, struct IOStdReq* ior)
+{
+    struct DriveGeometry* g = (struct DriveGeometry*)ior->io_Data;
+
+    // Derive a plausible CHS from the block count (SCSI reports no CHS):
+    // 1 head, 32 sectors/track.
+    ULONG spt = 32;
+    ULONG heads = 1;
+
+    memset(g, 0, sizeof(struct DriveGeometry));
+    g->dg_SectorSize = d->blocksize;
+    g->dg_TotalSectors = d->blocks;
+    g->dg_Cylinders = d->blocks / (spt * heads);
+    g->dg_CylSectors = spt * heads;
+    g->dg_Heads = heads;
+    g->dg_TrackSectors = spt;
+    g->dg_BufMemType = MEMF_PUBLIC;
+    g->dg_DeviceType = d->devtype;
+    g->dg_Flags = (d->flags & DRVF_REMOVABLE) ? DGF_REMOVABLE : 0;
+}
+
+static const UWORD nsd_supported[] =
+{
+    CMD_READ,
+    CMD_WRITE,
+    CMD_UPDATE,
+    CMD_CLEAR,
+    TD_CHANGENUM,
+    TD_CHANGESTATE,
+    TD_PROTSTATUS,
+    TD_GETGEOMETRY,
+    TD_READ64,
+    TD_WRITE64,
+    TD_SEEK64,
+    NSCMD_TD_READ64,
+    NSCMD_TD_WRITE64,
+    NSCMD_TD_SEEK64,
+    HD_SCSICMD,
+    0,
+};
+
+static BOOL device_query(struct IOStdReq* ior)
+{
+    struct NSDeviceQueryResult* q = (struct NSDeviceQueryResult*)ior->io_Data;
+
+    if (!q)
+        return FALSE;
+
+    q->nsdqr_DevQueryFormat = 0;
+    q->nsdqr_SizeAvailable = sizeof(struct NSDeviceQueryResult);
+    q->nsdqr_DeviceType = NSDEVTYPE_TRACKDISK;
+    q->nsdqr_DeviceSubType = 0;
+    q->nsdqr_SupportedCommands = (APTR)nsd_supported;
+    ior->io_Actual = sizeof(struct NSDeviceQueryResult);
+    return TRUE;
+}
+
+static void process_request(struct A314ScsiBase* base, struct IOStdReq* ior)
+{
+    struct Drive* d = (struct Drive*)ior->io_Unit;
+
+    ior->io_Error = 0;
+
+    switch (ior->io_Command)
+    {
+        case CMD_READ:
+        case TD_READ64:
+        case NSCMD_TD_READ64:
+            if (!d || !(d->flags & DRVF_PRESENT))
+            {
+                ior->io_Error = TDERR_DiskChanged;
+            }
+            else
+            {
+                do_read_write(base, d, ior, FALSE);
+            }
+            break;
+
+        case CMD_WRITE:
+        case TD_FORMAT:
+        case TD_WRITE64:
+        case NSCMD_TD_WRITE64:
+            if (!d || !(d->flags & DRVF_PRESENT))
+            {
+                ior->io_Error = TDERR_DiskChanged;
+            }
+            else if (d->flags & DRVF_WRITEPROT)
+            {
+                ior->io_Error = TDERR_WriteProt;
+            }
+            else
+            {
+                do_read_write(base, d, ior, TRUE);
+            }
+            break;
+
+        case HD_SCSICMD:
+            ior->io_Error = a314_scsi(base, d, (struct SCSICmd*)ior->io_Data);
+            break;
+
+        case TD_GETGEOMETRY:
+            if (d && (d->flags & DRVF_PRESENT))
+            {
+                get_geometry(d, ior);
+            }
+            else
+            {
+                ior->io_Error = TDERR_DiskChanged;
+            }
+            break;
+
+        default:
+            ior->io_Error = IOERR_NOCMD;
+            break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Processing task
+// ---------------------------------------------------------------------------
+
+static void startup(struct A314ScsiBase* base)
+{
+    kprintf("a314scsi: task startup\n");
+
+    base->reqport = CreatePort(NULL, 0);
+    if (!base->reqport)
+    {
+        kprintf("a314scsi: CreatePort FAILED\n");
+        return;
+    }
+
+    // a314.device was opened in init_device's caller context (see init_device).
+    // Here in the io task we only connect - the reply port must be owned by this
+    // task, which does every subsequent A314 transaction.
+    if (!base->a314base || !a314_connect(base))
+    {
+        kprintf("a314scsi: connect FAILED\n");
+        return;
+    }
+
+    // Probe every unit the host might serve; absent units fail INQUIRY in
+    // make_drive() and are simply skipped.
+    for (UWORD unit = 0; unit < A314SCSI_MAX_DRIVES; unit++)
+    {
+        struct Drive* d = make_drive(base, unit);
+        if (d)
+            mount_drive(base, d);
+    }
+}
+
+void task_body(void)
+{
+    struct A314ScsiBase* base = (struct A314ScsiBase*)FindTask(NULL)->tc_UserData;
+
+    startup(base);
+
+    // Tell init_device we finished starting up (success or not).
+    base->started = TRUE;
+    if (base->inittask)
+        Signal(base->inittask, base->initsig);
+
+    if (!base->reqport)
+        return; // startup failed; the device is unusable
+
+    for (;;)
+    {
+        WaitPort(base->reqport);
+
+        struct IOStdReq* ior;
+        while ((ior = (struct IOStdReq*)GetMsg(base->reqport)))
+        {
+            process_request(base, ior);
+            ReplyMsg(&ior->io_Message);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Device vectors
+// ---------------------------------------------------------------------------
+
+static void begin_io(__reg("a6") struct A314ScsiBase* base,
+                     __reg("a1") struct IOStdReq* ior)
+{
+    ior->io_Error = 0;
+
+    switch (ior->io_Command)
+    {
+        case NSCMD_DEVICEQUERY:
+            if (!device_query(ior))
+            {
+                ior->io_Error = IOERR_NOCMD;
+            }
+            break;
+
+        case TD_CHANGESTATE:
+        {
+            struct Drive* d = (struct Drive*)ior->io_Unit;
+            ior->io_Actual = (d && (d->flags & DRVF_PRESENT)) ? 0 : 1;
+            break;
+        }
+
+        case TD_CHANGENUM:
+            // Fixed disk: the media never changes, so the count stays 0.
+            ior->io_Actual = 0;
+            break;
+
+        case TD_PROTSTATUS:
+        {
+            struct Drive* d = (struct Drive*)ior->io_Unit;
+            ior->io_Actual = (d && (d->flags & DRVF_WRITEPROT)) ? 1 : 0;
+            break;
+        }
+
+        case CMD_CLEAR:
+        case CMD_UPDATE:
+        case TD_MOTOR:
+        case TD_SEEK:
+        case TD_SEEK64:
+        case NSCMD_TD_SEEK64:
+        case TD_REMOVE:
+            // No-ops.
+            break;
+
+        default:
+            // Handled asynchronously by the io task.
+            PutMsg(base->reqport, &ior->io_Message);
+            ior->io_Flags &= ~IOF_QUICK;
+            return;
+    }
+
+    if (!(ior->io_Flags & IOF_QUICK))
+    {
+        ReplyMsg(&ior->io_Message);
+    }
+}
+
+static ULONG abort_io(__reg("a6") struct A314ScsiBase* base,
+                      __reg("a1") struct IOStdReq* ior)
+{
+    return IOERR_NOCMD;
+}
+
+static void open(__reg("a6") struct A314ScsiBase* base,
+                 __reg("a1") struct IOStdReq* ior,
+                 __reg("d0") ULONG unitnum,
+                 __reg("d1") ULONG flags)
+{
+    kprintf("a314scsi: open unit=%ld\n", unitnum);
+
+    ior->io_Error = IOERR_OPENFAIL;
+    ior->io_Message.mn_Node.ln_Type = NT_REPLYMSG;
+
+    // Decode the Amiga unit (LUN*10 + ID) to a flat host unit. Each host disk is
+    // a separate LUN with ID 0, so only 0, 10, 20, ... are valid. Done by
+    // subtraction because a 32-bit divide isn't linked under -nostdlib.
+    ULONG rem = unitnum;
+    UWORD host = 0;
+    while (rem >= A314SCSI_UNIT_STEP && host < A314SCSI_MAX_DRIVES)
+    {
+        rem -= A314SCSI_UNIT_STEP;
+        host++;
+    }
+    if (rem != 0 || host >= A314SCSI_MAX_DRIVES)
+    {
+        return; // non-zero ID, or LUN out of range
+    }
+
+    struct Drive* d = find_drive(base, host);
+    if (!d)
+    {
+        return;
+    }
+
+    ior->io_Unit = (struct Unit*)d;
+    ior->io_Device = (struct Device*)base;
+    d->opencount++;
+    base->device.dd_Library.lib_OpenCnt++;
+    ior->io_Error = 0;
+}
+
+static BPTR expunge(__reg("a6") struct A314ScsiBase* base)
+{
+    // No unload support.
+    base->device.dd_Library.lib_Flags |= LIBF_DELEXP;
+    return 0;
+}
+
+static BPTR close(__reg("a6") struct A314ScsiBase* base,
+                  __reg("a1") struct IOStdReq* ior)
+{
+    struct Drive* d = (struct Drive*)ior->io_Unit;
+    if (d && d->opencount)
+    {
+        d->opencount--;
+    }
+
+    ior->io_Unit = NULL;
+    ior->io_Device = NULL;
+
+    base->device.dd_Library.lib_OpenCnt--;
+    return 0;
+}
+
+static struct Library* init_device(__reg("a6") struct ExecBase* sys_base,
+                                   __reg("a0") BPTR seg_list,
+                                   __reg("d0") struct A314ScsiBase* base)
+{
+    kprintf("a314scsi: init_device seg_list=%lx\n", (ULONG)seg_list);
+
+    base->sysbase = sys_base;
+    base->seglist = seg_list;
+
+    base->device.dd_Library.lib_Node.ln_Type = NT_DEVICE;
+    base->device.dd_Library.lib_Node.ln_Name = (char*)device_name;
+    base->device.dd_Library.lib_Flags = LIBF_SUMUSED | LIBF_CHANGED;
+    base->device.dd_Library.lib_Version = DEVICE_VERSION;
+    base->device.dd_Library.lib_Revision = DEVICE_REVISION;
+    base->device.dd_Library.lib_IdString = (APTR)id_string;
+
+    base->stack = AllocMem(TASK_STACK_SIZE, MEMF_PUBLIC | MEMF_CLEAR);
+    if (!base->stack)
+    {
+        kprintf("a314scsi: stack alloc FAILED\n");
+        return NULL;
+    }
+
+    // Open a314.device here, in the caller's (normal process) context. Opening it
+    // from the freshly-created io task hangs. If it fails the device still loads;
+    // the io task just won't connect.
+    if (!a314_open_device(base))
+    {
+        kprintf("a314scsi: a314_open_device FAILED\n");
+    }
+
+    BYTE sig = AllocSignal(-1);
+    base->inittask = FindTask(NULL);
+    base->initsig = (sig == -1) ? 0 : (1UL << sig);
+    base->started = FALSE;
+
+    struct Task* t = &base->iotask;
+    t->tc_Node.ln_Type = NT_TASK;
+    t->tc_Node.ln_Pri = TASK_PRIORITY;
+    t->tc_Node.ln_Name = (char*)device_name;
+    t->tc_SPLower = base->stack;
+    t->tc_SPUpper = (APTR)((UBYTE*)base->stack + TASK_STACK_SIZE);
+    t->tc_SPReg = t->tc_SPUpper;
+    t->tc_UserData = base;
+    NewList(&t->tc_MemEntry);
+
+    kprintf("a314scsi: starting task\n");
+    AddTask(t, (APTR)task_body, 0);
+
+    if (sig != -1)
+    {
+        Wait(base->initsig);
+        FreeSignal(sig);
+    }
+
+    base->inittask = NULL;
+
+    kprintf("a314scsi: init_device done\n");
+    return &base->device.dd_Library;
+}
+
+const ULONG device_vectors[] =
+{
+    (ULONG)open,
+    (ULONG)close,
+    (ULONG)expunge,
+    0,
+    (ULONG)begin_io,
+    (ULONG)abort_io,
+    (ULONG)-1,
+};
+
+const ULONG auto_init_tables[] =
+{
+    sizeof(struct A314ScsiBase),
+    (ULONG)device_vectors,
+    0,
+    (ULONG)init_device,
+};

--- a/Software/scsi/device.c
+++ b/Software/scsi/device.c
@@ -24,7 +24,7 @@
 extern void task_body(void);
 
 const char device_name[] = DEVICE_NAME;
-const char id_string[] = DEVICE_NAME " 1.0 (9.9.2025)";
+const char id_string[] = DEVICE_NAME " 1.0 (4.7.2026)";
 
 // ---------------------------------------------------------------------------
 // Drive lookup / discovery
@@ -195,6 +195,10 @@ static const UWORD nsd_supported[] =
     CMD_WRITE,
     CMD_UPDATE,
     CMD_CLEAR,
+    TD_MOTOR,
+    TD_SEEK,
+    TD_FORMAT,
+    TD_REMOVE,
     TD_CHANGENUM,
     TD_CHANGESTATE,
     TD_PROTSTATUS,
@@ -395,8 +399,8 @@ static void begin_io(__reg("a6") struct A314ScsiBase* base,
 
         default:
             // Handled asynchronously by the io task.
-            PutMsg(base->reqport, &ior->io_Message);
             ior->io_Flags &= ~IOF_QUICK;
+            PutMsg(base->reqport, &ior->io_Message);
             return;
     }
 

--- a/Software/scsi/kprintf.c
+++ b/Software/scsi/kprintf.c
@@ -1,0 +1,32 @@
+#include <stdint.h>
+#include <stdarg.h>
+
+#include <inline/exec_protos.h>
+
+#include "kprintf.h"
+
+#ifdef ENABLE_KPRINTF
+
+static void set_uart_speed(__reg("d0") uint32_t c) = "\tmove.w\td0,$dff032\n";
+static void RawPutChar(__reg("d0") uint32_t c, __reg("a6") struct ExecBase* SysBase) = "\tjsr\t-516(a6)\n";
+
+static void raw_put_char(__reg("d0") uint32_t c, __reg("a3") struct ExecBase* SysBase)
+{
+    RawPutChar(c, (APTR)SysBase);
+}
+
+void kprintf(const char* format, ...)
+{
+    va_list args;
+    struct ExecBase* SysBase = *((struct ExecBase**)(4L));
+
+    // set_uart_speed(3546895 / 115200);
+
+    va_start(args, format);
+
+    RawDoFmt((STRPTR)format, (APTR)args, raw_put_char, (APTR)SysBase);
+
+    va_end(args);
+}
+
+#endif

--- a/Software/scsi/kprintf.h
+++ b/Software/scsi/kprintf.h
@@ -1,0 +1,10 @@
+#ifndef KPRINTF_H
+#define KPRINTF_H
+
+#ifdef ENABLE_KPRINTF
+void kprintf(const char* fmt, ...);
+#else
+#define kprintf(...)  do { } while (0)
+#endif
+
+#endif

--- a/Software/scsi/lseg.c
+++ b/Software/scsi/lseg.c
@@ -1,0 +1,270 @@
+#include <exec/types.h>
+#include <exec/memory.h>
+
+#include <libraries/dos.h> // BPTR, MKBADDR
+#include <dos/doshunks.h>  // HUNK_*
+
+#include <devices/hardblocks.h> // IDNAME_LOADSEG, struct LoadSegBlock
+
+#include <proto/exec.h>
+
+#include <string.h>
+#include <stddef.h> // offsetof
+
+#include "a314scsi.h"
+#include "kprintf.h"
+
+#define SysBase (*(struct ExecBase**)4)
+
+#define LSEG_DATA_OFFSET offsetof(struct LoadSegBlock, lsb_LoadData)
+#define LSEG_MAX_BLOCKS 8192
+
+// Read one LSEG block into blk and validate it. On success returns TRUE and
+// stores lsb_Next; on read error or a non-LSEG block returns FALSE.
+static BOOL read_lseg_block(struct A314ScsiBase* base, struct Drive* d, ULONG b, UBYTE* blk, ULONG* next)
+{
+    if (scsi_rw(base, d, b, 1, blk, FALSE) != 0)
+    {
+        return FALSE;
+    }
+
+    struct LoadSegBlock* lsb = (struct LoadSegBlock*)blk;
+    if (lsb->lsb_ID != IDNAME_LOADSEG)
+    {
+        return FALSE;
+    }
+    *next = lsb->lsb_Next;
+    return TRUE;
+}
+
+// Reassemble the LSEG chain into one contiguous buffer. Returns the buffer
+// (caller FreeMem's *out_len bytes) or NULL. The chain is walked twice - once to
+// size the buffer, once to fill it - rather than growing it dynamically.
+static UBYTE* read_lseg_chain(struct A314ScsiBase* base, struct Drive* d, ULONG first, ULONG* out_len)
+{
+    ULONG bs = d->blocksize;
+    ULONG per = bs - LSEG_DATA_OFFSET;
+
+    UBYTE* blk = (UBYTE*)AllocMem(bs, MEMF_PUBLIC);
+    if (!blk)
+    {
+        return NULL;
+    }
+
+    ULONG next;
+
+    ULONG count = 0;
+    ULONG b = first;
+    while (b != 0xFFFFFFFFUL && b != 0 && count < LSEG_MAX_BLOCKS)
+    {
+        if (!read_lseg_block(base, d, b, blk, &next))
+        {
+            break;
+        }
+        count++;
+        b = next;
+    }
+
+    if (!count)
+    {
+        FreeMem(blk, bs);
+        return NULL;
+    }
+
+    ULONG total = count * per;
+    UBYTE* buf = (UBYTE*)AllocMem(total, MEMF_PUBLIC);
+    if (!buf)
+    {
+        FreeMem(blk, bs);
+        return NULL;
+    }
+
+    b = first;
+    ULONG off = 0;
+    for (ULONG i = 0; i < count; i++)
+    {
+        if (!read_lseg_block(base, d, b, blk, &next))
+        {
+            break;
+        }
+        memcpy(buf + off, ((struct LoadSegBlock*)blk)->lsb_LoadData, per);
+        off += per;
+        b = next;
+    }
+
+    FreeMem(blk, bs);
+    *out_len = total;
+    return buf;
+}
+
+BPTR load_seglist(struct A314ScsiBase* base, struct Drive* d, ULONG first)
+{
+    ULONG len = 0;
+    UBYTE* data = read_lseg_chain(base, d, first, &len);
+    if (!data)
+    {
+        kprintf("a314scsi: LSEG read failed\n");
+        return 0;
+    }
+
+    ULONG* p = (ULONG*)data;
+    ULONG* end = (ULONG*)(data + len);
+
+    if (*p++ != HUNK_HEADER)
+    {
+        kprintf("a314scsi: not a HUNK_HEADER\n");
+        FreeMem(data, len);
+        return 0;
+    }
+
+    // Skip resident-library name list.
+    while (p < end && *p)
+    {
+        ULONG n = *p++;
+        p += n;
+    }
+    p++; // terminating 0
+
+    p++; // table size (unused)
+    ULONG firstHunk = *p++;
+    ULONG lastHunk = *p++;
+    ULONG numHunks = lastHunk - firstHunk + 1;
+
+    APTR* seg = (APTR*)AllocMem(numHunks * sizeof(APTR), MEMF_PUBLIC | MEMF_CLEAR);
+    ULONG* segBytes = (ULONG*)AllocMem(numHunks * sizeof(ULONG), MEMF_PUBLIC | MEMF_CLEAR);
+    if (!seg || !segBytes)
+    {
+        if (seg)
+        {
+            FreeMem(seg, numHunks * sizeof(APTR));
+        }
+        if (segBytes)
+        {
+            FreeMem(segBytes, numHunks * sizeof(ULONG));
+        }
+        FreeMem(data, len);
+        return 0;
+    }
+
+    // Allocate each hunk as a SegList node: [ULONG length][BPTR next][data...].
+    for (ULONG i = 0; i < numHunks; i++)
+    {
+        ULONG raw = *p++;
+        ULONG longs = raw & 0x3FFFFFFFUL;
+        ULONG mf = MEMF_PUBLIC | MEMF_CLEAR;
+        ULONG memtype = raw & 0xC0000000UL;
+        if (memtype == 0x40000000UL)
+        {
+            mf = MEMF_CHIP | MEMF_CLEAR;
+        }
+        else if (memtype == 0xC0000000UL)
+        {
+            p++; // explicit memflags longword - skip, allocate public
+        }
+
+        ULONG bytes = longs * 4;
+        UBYTE* a = (UBYTE*)AllocMem(bytes + 8, mf);
+        if (!a)
+        {
+            // Out of memory mid-load - only realistic at coldstart OOM, where the
+            // boot is failing anyway. Bail and leak; the unwind isn't worth it.
+            kprintf("a314scsi: hunk alloc failed\n");
+            return 0;
+        }
+        seg[i] = a;
+        segBytes[i] = bytes;
+    }
+
+    // Parse the hunks into the allocated segments.
+    ULONG idx = 0;
+    while (p < end && idx < numHunks)
+    {
+        ULONG htype = *p++ & 0x3FFFFFFFUL;
+
+        if (htype == HUNK_CODE || htype == HUNK_DATA)
+        {
+            ULONG longs = *p++;
+            memcpy((UBYTE*)seg[idx] + 8, p, longs * 4);
+            p += longs;
+        }
+        else if (htype == HUNK_BSS)
+        {
+            p++; // size (already allocated and cleared)
+        }
+        else if (htype == HUNK_RELOC32)
+        {
+            for (;;)
+            {
+                ULONG cnt = *p++;
+                if (!cnt)
+                {
+                    break;
+                }
+                ULONG refHunk = *p++;
+                if (refHunk >= numHunks)
+                {
+                    // Malformed LSEG: don't index seg[] out of bounds. Skip this
+                    // block's offsets and keep the parse position valid.
+                    kprintf("a314scsi: reloc refHunk %ld >= %ld\n", refHunk, numHunks);
+                    p += cnt;
+                    continue;
+                }
+                UBYTE* thisData = (UBYTE*)seg[idx] + 8;
+                ULONG addBase = (ULONG)((UBYTE*)seg[refHunk] + 8);
+                for (ULONG j = 0; j < cnt; j++)
+                {
+                    ULONG offset = *p++;
+                    UBYTE* loc = thisData + offset; // may be odd -> byte-wise
+                    ULONG v = ((ULONG)loc[0] << 24) | ((ULONG)loc[1] << 16) | ((ULONG)loc[2] << 8) | loc[3];
+                    v += addBase;
+                    loc[0] = (UBYTE)(v >> 24);
+                    loc[1] = (UBYTE)(v >> 16);
+                    loc[2] = (UBYTE)(v >> 8);
+                    loc[3] = (UBYTE)v;
+                }
+            }
+        }
+        else if (htype == HUNK_SYMBOL)
+        {
+            // { namelen-longs, name..., value } * , terminated by 0
+            while (p < end && *p)
+            {
+                ULONG n = *p++;
+                p += n;  // name
+                p++;     // value
+            }
+            p++; // terminating 0
+        }
+        else if (htype == HUNK_DEBUG || htype == HUNK_NAME)
+        {
+            ULONG n = *p++;
+            p += n;
+        }
+        else if (htype == HUNK_END)
+        {
+            idx++;
+        }
+        else
+        {
+            kprintf("a314scsi: bad hunk type %lx\n", htype);
+            break;
+        }
+    }
+
+    // Link the SegList and build the result BPTR (points at each node's next field).
+    for (ULONG i = 0; i < numHunks; i++)
+    {
+        ULONG* node = (ULONG*)seg[i];
+        node[0] = segBytes[i] + 8;
+        node[1] = (i + 1 < numHunks) ? (ULONG)MKBADDR((UBYTE*)seg[i + 1] + 4) : 0;
+    }
+
+    BPTR result = MKBADDR((UBYTE*)seg[0] + 4);
+
+    FreeMem(seg, numHunks * sizeof(APTR));
+    FreeMem(segBytes, numHunks * sizeof(ULONG));
+    FreeMem(data, len);
+
+    kprintf("a314scsi: loaded seglist %ld hunks -> BPTR %lx\n", numHunks, (ULONG)result);
+    return result;
+}

--- a/Software/scsi/lseg.c
+++ b/Software/scsi/lseg.c
@@ -177,6 +177,7 @@ BPTR load_seglist(struct A314ScsiBase* base, struct Drive* d, ULONG first)
 
     // Parse the hunks into the allocated segments.
     ULONG idx = 0;
+    BOOL failed = FALSE;
     while (p < end && idx < numHunks)
     {
         ULONG htype = *p++ & 0x3FFFFFFFUL;
@@ -247,8 +248,24 @@ BPTR load_seglist(struct A314ScsiBase* base, struct Drive* d, ULONG first)
         else
         {
             kprintf("a314scsi: bad hunk type %lx\n", htype);
+            failed = TRUE;
             break;
         }
+    }
+
+    if (failed || idx != numHunks)
+    {
+        for (ULONG i = 0; i < numHunks; i++)
+        {
+            if (seg[i])
+            {
+                FreeMem(seg[i], segBytes[i] + 8);
+            }
+        }
+        FreeMem(seg, numHunks * sizeof(APTR));
+        FreeMem(segBytes, numHunks * sizeof(ULONG));
+        FreeMem(data, len);
+        return 0;
     }
 
     // Link the SegList and build the result BPTR (points at each node's next field).

--- a/Software/scsi/rdb.c
+++ b/Software/scsi/rdb.c
@@ -145,6 +145,9 @@ static void mount_partition(struct A314ScsiBase* base, struct Drive* d, struct P
         me->env_vec[i] = env[i];
     }
 
+    if (me->env_vec[0] > env_longs - 1)
+        me->env_vec[0] = env_longs - 1;
+
     // Drive name (from the partition) and exec device name, as BCPL strings.
     UBYTE dn_len = ((const UBYTE*)pb->pb_DriveName)[0];
     if (dn_len > 34)
@@ -239,10 +242,17 @@ void mount_drive(struct A314ScsiBase* base, struct Drive* d)
         }
 
         struct RigidDiskBlock* r = (struct RigidDiskBlock*)buf;
-        if (r->rdb_ID == IDNAME_RIGIDDISK && sum_block((ULONG*)buf, r->rdb_SummedLongs) == 0)
+        if (r->rdb_ID == IDNAME_RIGIDDISK)
         {
-            rdb = r;
-            break;
+            ULONG longs = r->rdb_SummedLongs;
+            if (longs > d->blocksize / 4)
+                longs = d->blocksize / 4;
+
+            if (sum_block((ULONG*)buf, longs) == 0)
+            {
+                rdb = r;
+                break;
+            }
         }
     }
 
@@ -275,8 +285,12 @@ void mount_drive(struct A314ScsiBase* base, struct Drive* d)
                     break;
                 }
 
-                mount_partition(base, d, pb, fstab, fscount, expansion);
-                part_block = pb->pb_Next;
+                ULONG next = pb->pb_Next;
+                if (!(pb->pb_Flags & PBFF_NOMOUNT))
+                {
+                    mount_partition(base, d, pb, fstab, fscount, expansion);
+                }
+                part_block = next;
             }
             CloseLibrary((struct Library*)expansion);
         }

--- a/Software/scsi/rdb.c
+++ b/Software/scsi/rdb.c
@@ -1,0 +1,292 @@
+#include <exec/types.h>
+#include <exec/memory.h>
+#include <exec/nodes.h>
+#include <exec/lists.h>
+
+#include <libraries/dos.h>
+#include <libraries/dosextens.h>
+#include <libraries/filehandler.h>
+#include <libraries/expansion.h>
+#include <libraries/expansionbase.h>
+
+#include <devices/hardblocks.h>
+
+#include <proto/exec.h>
+
+#include <string.h>
+
+#include "a314scsi.h"
+#include "kprintf.h"
+
+#define SysBase (*(struct ExecBase**)4)
+
+#define RDB_SCAN_LIMIT 16 // the RDB must live within the first 16 blocks
+#define MAX_LOADED_FS 8
+
+// fhb_PatchFlags bits (which DeviceNode fields the FSHB overrides).
+#define FSPF_TYPE       (1 << 0)
+#define FSPF_STACKSIZE  (1 << 4)
+#define FSPF_PRIORITY   (1 << 5)
+#define FSPF_GLOBALVEC  (1 << 8)
+
+struct LoadedFS
+{
+    ULONG   dostype;
+    BPTR    seglist;
+    ULONG   globalvec;
+    ULONG   patchflags;
+    ULONG   stacksize;
+    LONG    priority;
+    ULONG   dntype;
+};
+
+struct MountEntry
+{
+    struct          DeviceNode dev_node;
+    struct          FileSysStartupMsg fssm;
+    ULONG           env_vec[20];
+    char            drive_name[36];  // BCPL string
+    char            exec_name[24];   // BCPL string
+    struct BootNode boot_node;
+};
+
+static ULONG sum_block(const ULONG* p, ULONG longs)
+{
+    ULONG sum = 0;
+    for (ULONG i = 0; i < longs; i++)
+    {
+        sum += p[i];
+    }
+    return sum;
+}
+
+static BOOL read_block(struct A314ScsiBase* base, struct Drive* d, ULONG block, APTR buf)
+{
+    return scsi_rw(base, d, block, 1, buf, FALSE) == 0;
+}
+
+// Copy a BCPL-style string (len byte + chars) into a BCPL field.
+static void set_bcpl(char* dst, const char* src, UBYTE len)
+{
+    dst[0] = len;
+    for (UBYTE i = 0; i < len; i++)
+    {
+        dst[1 + i] = src[i];
+    }
+}
+
+// Walk the RDB FileSysHeaderBlock list, loading each filesystem's seglist.
+static ULONG load_filesystems(struct A314ScsiBase* base, struct Drive* d, ULONG fshList, struct LoadedFS* tab)
+{
+    APTR buf = AllocMem(d->blocksize, MEMF_PUBLIC | MEMF_CLEAR);
+    if (!buf)
+    {
+        return 0;
+    }
+
+    ULONG n = 0;
+    ULONG b = fshList;
+    while (b != 0xFFFFFFFFUL && b != 0 && n < MAX_LOADED_FS)
+    {
+        if (!read_block(base, d, b, buf))
+        {
+            break;
+        }
+
+        struct FileSysHeaderBlock* fhb = (struct FileSysHeaderBlock*)buf;
+        if (fhb->fhb_ID != IDNAME_FILESYSHEADER)
+        {
+            break;
+        }
+
+        ULONG dostype = fhb->fhb_DosType;
+        ULONG seg = fhb->fhb_SegListBlocks;
+        ULONG next = fhb->fhb_Next;
+
+        kprintf("a314scsi: FSHD dostype=%lx segblock=%ld\n", dostype, seg);
+
+        BPTR seglist = load_seglist(base, d, seg);
+        if (seglist)
+        {
+            tab[n].dostype      = dostype;
+            tab[n].seglist      = seglist;
+            tab[n].globalvec    = fhb->fhb_GlobalVec;
+            tab[n].patchflags   = fhb->fhb_PatchFlags;
+            tab[n].stacksize    = fhb->fhb_StackSize;
+            tab[n].priority     = fhb->fhb_Priority;
+            tab[n].dntype       = fhb->fhb_Type;
+            n++;
+        }
+
+        b = next;
+    }
+
+    FreeMem(buf, d->blocksize);
+    return n;
+}
+
+static void mount_partition(struct A314ScsiBase* base, struct Drive* d, struct PartitionBlock* pb,
+                            struct LoadedFS* fstab, ULONG fscount, struct ExpansionBase* expansion)
+{
+    struct MountEntry* me = (struct MountEntry*)AllocMem(sizeof(struct MountEntry), MEMF_PUBLIC | MEMF_CLEAR);
+    if (!me)
+    {
+        return;
+    }
+
+    const ULONG* env = (const ULONG*)pb->pb_Environment;
+    ULONG env_longs = env[0] + 1; // de_TableSize + 1
+    if (env_longs > 20)
+    {
+        env_longs = 20;
+    }
+    for (ULONG i = 0; i < env_longs; i++)
+    {
+        me->env_vec[i] = env[i];
+    }
+
+    // Drive name (from the partition) and exec device name, as BCPL strings.
+    UBYTE dn_len = ((const UBYTE*)pb->pb_DriveName)[0];
+    if (dn_len > 34)
+    {
+        dn_len = 34;
+    }
+    set_bcpl(me->drive_name, (const char*)&pb->pb_DriveName[1], dn_len);
+    set_bcpl(me->exec_name, device_name, (UBYTE)strlen(device_name));
+
+    me->fssm.fssm_Unit          = d->number * A314SCSI_UNIT_STEP;
+    me->fssm.fssm_Device        = MKBADDR(me->exec_name);
+    me->fssm.fssm_Environ       = MKBADDR(me->env_vec);
+    me->fssm.fssm_Flags         = 0;
+
+    me->dev_node.dn_Type        = 0;
+    me->dev_node.dn_StackSize   = 600;
+    me->dev_node.dn_Priority    = 10;
+    me->dev_node.dn_Startup     = MKBADDR(&me->fssm);
+    me->dev_node.dn_Name        = MKBADDR(me->drive_name);
+    me->dev_node.dn_GlobalVec   = -1;
+
+    // If the partition's DOSType matches a filesystem we loaded from the RDB,
+    // point the DeviceNode at it (patching the fields the FSHB requests).
+    ULONG dostype = env[DE_DOSTYPE];
+    for (ULONG i = 0; i < fscount; i++)
+    {
+        if (fstab[i].dostype == dostype)
+        {
+            me->dev_node.dn_SegList = fstab[i].seglist;
+            if (fstab[i].patchflags & FSPF_GLOBALVEC)
+            {
+                me->dev_node.dn_GlobalVec = fstab[i].globalvec;
+            }
+            if (fstab[i].patchflags & FSPF_TYPE)
+            {
+                me->dev_node.dn_Type = fstab[i].dntype;
+            }
+            if (fstab[i].patchflags & FSPF_STACKSIZE)
+            {
+                me->dev_node.dn_StackSize = fstab[i].stacksize;
+            }
+            if (fstab[i].patchflags & FSPF_PRIORITY)
+            {
+                me->dev_node.dn_Priority = fstab[i].priority;
+            }
+            kprintf("a314scsi: partition FS dostype=%lx -> seglist %lx\n", dostype, (ULONG)fstab[i].seglist);
+            break;
+        }
+    }
+
+    LONG bootpri = (LONG)env[DE_BOOTPRI];
+    BOOL bootable = (pb->pb_Flags & PBFF_BOOTABLE) ? TRUE : FALSE;
+
+    me->boot_node.bn_Node.ln_Type   = NT_BOOTNODE;
+    me->boot_node.bn_Node.ln_Pri    = bootable ? (BYTE)bootpri : -128;
+    me->boot_node.bn_Node.ln_Name   = NULL;
+    me->boot_node.bn_DeviceNode     = (APTR)&me->dev_node;
+
+    kprintf("a314scsi: mount partition (bootpri=%ld bootable=%ld)\n", bootpri, (ULONG)bootable);
+
+    Forbid();
+    Enqueue(&expansion->MountList, &me->boot_node.bn_Node);
+    Permit();
+}
+
+void mount_drive(struct A314ScsiBase* base, struct Drive* d)
+{
+    kprintf("a314scsi: mount_drive unit=%ld blocksize=%ld\n", (ULONG)d->number, d->blocksize);
+
+    if (d->flags & DRVF_MOUNTED)
+    {
+        return;
+    }
+
+    // One block buffer serves the whole routine: first the RDB scan, then each
+    // partition block in turn.
+    APTR buf = AllocMem(d->blocksize, MEMF_PUBLIC | MEMF_CLEAR);
+    if (!buf)
+    {
+        kprintf("a314scsi: mount_drive AllocMem FAILED\n");
+        return;
+    }
+
+    // Find the RigidDiskBlock within the first few sectors.
+    struct RigidDiskBlock* rdb = NULL;
+    for (ULONG block = 0; block < RDB_SCAN_LIMIT; block++)
+    {
+        if (!read_block(base, d, block, buf))
+        {
+            kprintf("a314scsi: read block %ld FAILED\n", block);
+            break;
+        }
+
+        struct RigidDiskBlock* r = (struct RigidDiskBlock*)buf;
+        if (r->rdb_ID == IDNAME_RIGIDDISK && sum_block((ULONG*)buf, r->rdb_SummedLongs) == 0)
+        {
+            rdb = r;
+            break;
+        }
+    }
+
+    if (rdb)
+    {
+        kprintf("a314scsi: RDB found on unit %ld\n", (ULONG)d->number);
+
+        // Grab the chain heads before buf gets reused for partition blocks.
+        ULONG fsh_list = rdb->rdb_FileSysHeaderList;
+        ULONG part_block = rdb->rdb_PartitionList;
+
+        struct LoadedFS fstab[MAX_LOADED_FS];
+        ULONG fscount = load_filesystems(base, d, fsh_list, fstab);
+        kprintf("a314scsi: %ld filesystem(s) loaded\n", fscount);
+
+        // Enqueue every partition on the expansion MountList (opened once).
+        struct ExpansionBase* expansion = (struct ExpansionBase*)OpenLibrary((STRPTR)EXPANSIONNAME, 0);
+        if (expansion)
+        {
+            while (part_block != 0xFFFFFFFFUL && part_block != 0)
+            {
+                if (!read_block(base, d, part_block, buf))
+                {
+                    break;
+                }
+
+                struct PartitionBlock* pb = (struct PartitionBlock*)buf;
+                if (pb->pb_ID != IDNAME_PARTITION)
+                {
+                    break;
+                }
+
+                mount_partition(base, d, pb, fstab, fscount, expansion);
+                part_block = pb->pb_Next;
+            }
+            CloseLibrary((struct Library*)expansion);
+        }
+
+        d->flags |= DRVF_MOUNTED;
+    }
+    else
+    {
+        kprintf("a314scsi: no RDB on unit %ld\n", (ULONG)d->number);
+    }
+
+    FreeMem(buf, d->blocksize);
+}

--- a/Software/scsi/romtag.asm
+++ b/Software/scsi/romtag.asm
@@ -1,0 +1,29 @@
+    XREF    _device_name
+    XREF    _id_string
+    XREF    _auto_init_tables
+    XREF    _cli_main
+
+RTC_MATCHWORD:  equ    $4afc
+RTF_AUTOINIT:   equ    (1<<7)
+RTF_COLDSTART:  equ    (1<<0)
+NT_DEVICE:      equ    3
+VERSION:        equ    1
+PRIORITY:       equ    -5
+
+        section    CODE,code
+
+        jsr     _cli_main
+        rts
+
+romtag:
+        dc.w    RTC_MATCHWORD
+        dc.l    romtag
+        dc.l    endcode
+        dc.b    RTF_AUTOINIT|RTF_COLDSTART
+        dc.b    VERSION
+        dc.b    NT_DEVICE
+        dc.b    PRIORITY
+        dc.l    _device_name
+        dc.l    _id_string
+        dc.l    _auto_init_tables
+endcode:

--- a/Software/scsi/scsi.conf
+++ b/Software/scsi/scsi.conf
@@ -1,0 +1,10 @@
+{
+    "units": [
+        {
+            "unit": 0,
+            "filename": "##HOME##/a314shared/hdfs/Harddisk.hdf",
+            "rw": true,
+            "block_size": 512
+        }
+    ]
+}

--- a/Software/scsi/scsi.h
+++ b/Software/scsi/scsi.h
@@ -1,0 +1,33 @@
+#ifndef SCSI_H
+#define SCSI_H
+
+// Command operation codes (CDB byte 0).
+#define SCSI_CMD_TEST_UNIT_READY 		0x00
+#define SCSI_CMD_REQUEST_SENSE 			0x03
+#define SCSI_CMD_INQUIRY 				0x12
+#define SCSI_CMD_MODE_SENSE_6 			0x1A
+#define SCSI_CMD_READ_CAPACITY_10 		0x25
+#define SCSI_CMD_READ_10 				0x28
+#define SCSI_CMD_WRITE_10 				0x2A
+
+// INQUIRY standard data.
+#define SCSI_INQ_PDT_MASK 	0x1F // byte 0: peripheral device type
+#define SCSI_INQ_RMB 		0x80 // byte 1: removable medium bit
+
+// MODE SENSE(6).
+#define SCSI_MODE_PAGE_RETURN_ALL 	0x3F // page code: all pages
+#define SCSI_MODE_HDR_WP 			0x80 // mode header device-specific: write protect
+
+// Fixed-format sense data (REQUEST SENSE / autosense).
+#define SCSI_SENSE_CURRENT_FIXED 0x70 // byte 0: response code
+#define SCSI_SENSE_ADD_LEN 6          // byte 7: additional sense length
+
+// Sense key (sense byte 2, low nibble).
+#define SCSI_SENSE_KEY_MASK 	0x0F
+#define SCSI_SK_NOT_READY 		0x02
+#define SCSI_SK_MEDIUM_ERROR 	0x03
+#define SCSI_SK_HARDWARE_ERROR 	0x04
+#define SCSI_SK_UNIT_ATTENTION 	0x06
+#define SCSI_SK_DATA_PROTECT 	0x07
+
+#endif

--- a/Software/scsi/scsi.py
+++ b/Software/scsi/scsi.py
@@ -1,0 +1,299 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+import json
+import logging
+import select
+import socket
+import struct
+from typing import Dict, List, Optional
+
+from a314d import A314d
+
+logging.basicConfig(format='%(levelname)s, %(asctime)s, %(name)s, line %(lineno)d: %(message)s', level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+SERVICE_NAME = 'scsi'
+CONF_FILE = '/etc/opt/a314/scsi.conf'
+
+# Wire protocol (matches a314scsi_protocol.h).
+REQ_FMT = '>BBBB16sBBHII'   # kind,unit,cdb_len,rsv,cdb,dir,pad,rsv,data_length,address
+RES_FMT = '>BBBBBBHI'       # kind,status,sense_key,asc,ascq,pad,rsv,actual_length
+CMD_RES = 2
+
+DIR_NONE = 0
+DIR_READ = 1
+DIR_WRITE = 2
+
+STATUS_GOOD = 0x00
+STATUS_CHECK_CONDITION = 0x02
+
+SENSE_NOT_READY = 0x02
+SENSE_ILLEGAL_REQUEST = 0x05
+
+
+class DiskImage(object):
+    def __init__(self, filename: str, writable: bool, block_size: int = 512):
+        self.filename = filename
+        self.writable = writable
+        self.block_size = block_size
+        self.f = None
+        self.blocks = 0
+        # Physical geometry reported via MODE SENSE (HDToolBox reads this).
+        self.cylinders = 0
+        self.heads = 0
+        self.sectors = 0  # sectors per track
+
+    def open(self) -> bool:
+        try:
+            self.f = open(self.filename, 'r+b' if self.writable else 'rb')
+            self.f.seek(0, 2)
+            self.blocks = self.f.tell() // self.block_size
+            self._compute_geometry()
+            logger.info('Opened %s: %d blocks x %d bytes (%dc/%dh/%ds)%s',
+                        self.filename, self.blocks, self.block_size,
+                        self.cylinders, self.heads, self.sectors,
+                        '' if self.writable else ' (read-only)')
+            return True
+        except Exception as e:
+            logger.error('Failed to open %s: %s', self.filename, e)
+            return False
+
+    def _compute_geometry(self):
+        # Prefer the RDB's own geometry so HDToolBox agrees with the on-disk
+        # partitioning; otherwise synthesize a plausible geometry.
+        self.f.seek(0)
+        b0 = self.f.read(self.block_size)
+        if b0[:4] == b'RDSK':
+            cyls = int.from_bytes(b0[64:68], 'big')
+            secs = int.from_bytes(b0[68:72], 'big')
+            heads = int.from_bytes(b0[72:76], 'big')
+            if cyls and secs and heads:
+                self.cylinders, self.sectors, self.heads = cyls, secs, heads
+                return
+        self.heads = 16
+        self.sectors = 63
+        self.cylinders = max(1, self.blocks // (self.heads * self.sectors))
+
+    def read(self, lba: int, blocks: int) -> Optional[bytes]:
+        if not self.f or lba + blocks > self.blocks:
+            return None
+        self.f.seek(lba * self.block_size)
+        return self.f.read(blocks * self.block_size)
+
+    def write(self, lba: int, data: bytes) -> bool:
+        if not self.f or not self.writable:
+            return False
+        if lba + (len(data) // self.block_size) > self.blocks:
+            return False
+        self.f.seek(lba * self.block_size)
+        self.f.write(data)
+        return True
+
+
+class ScsiService(object):
+    def __init__(self):
+        self.a314d = A314d(SERVICE_NAME)
+        self.current_stream_id: Optional[int] = None
+        self.rbuf = b''
+        self.images: Dict[int, DiskImage] = {}
+
+        # Pending bulk transfers awaiting a314 memory completion.
+        self.mem_write_queue = []   # (stream_id, status, sense_key, asc, ascq, actual)
+        self.mem_read_queue = []    # (stream_id, unit, cdb)
+
+    def load_config(self):
+        try:
+            with open(CONF_FILE, 'rt') as f:
+                j = json.load(f)
+        except Exception as e:
+            logger.warning('No config (%s): %s', CONF_FILE, e)
+            return
+        for e in j.get('units', []):
+            unit = e['unit']
+            img = DiskImage(e['filename'], e.get('rw', False), e.get('block_size', 512))
+            if img.open():
+                self.images[unit] = img
+
+    # --- SCSI CDB execution --------------------------------------------------
+
+    def inquiry_data(self, img: DiskImage) -> bytes:
+        d = bytearray(36)
+        d[0] = 0x00              # direct-access block device
+        d[1] = 0x00              # not removable
+        d[2] = 0x02              # SCSI-2
+        d[3] = 0x02              # response data format
+        d[4] = 31                # additional length
+        d[8:16] = b'A314    '
+        d[16:32] = b'HDF             '
+        d[32:36] = b'0001'
+        return bytes(d)
+
+    def read_capacity10(self, img: DiskImage) -> bytes:
+        last = img.blocks - 1
+        if last > 0xFFFFFFFF:
+            last = 0xFFFFFFFF
+        return struct.pack('>II', last, img.block_size)
+
+    def mode_page_format(self, img: DiskImage) -> bytes:
+        # Page 3: Format Device Parameters - carries the sectors-per-track that
+        # HDToolBox reports as "track size".
+        p = bytearray(24)
+        p[0] = 0x03
+        p[1] = 22
+        struct.pack_into('>H', p, 10, img.sectors & 0xFFFF)     # sectors per track
+        struct.pack_into('>H', p, 12, img.block_size & 0xFFFF)  # bytes per sector
+        return bytes(p)
+
+    def mode_page_geometry(self, img: DiskImage) -> bytes:
+        # Page 4: Rigid Disk Drive Geometry - cylinders and heads.
+        p = bytearray(24)
+        p[0] = 0x04
+        p[1] = 22
+        cyl = img.cylinders
+        p[2] = (cyl >> 16) & 0xFF
+        p[3] = (cyl >> 8) & 0xFF
+        p[4] = cyl & 0xFF
+        p[5] = img.heads & 0xFF
+        return bytes(p)
+
+    def mode_sense6(self, img: DiskImage, cdb: bytes) -> bytes:
+        page = cdb[2] & 0x3F
+        wp = 0x80 if not img.writable else 0x00
+        body = b''
+        if page in (0x03, 0x3F):
+            body += self.mode_page_format(img)
+        if page in (0x04, 0x3F):
+            body += self.mode_page_geometry(img)
+        # Header: mode data length, medium type, device-specific (WP), block-desc length.
+        header = bytes([3 + len(body), 0, wp, 0])
+        return header + body
+
+    # Execute a device->host / no-data command, returning (status, sk, asc, ascq, data).
+    def exec_read(self, img: DiskImage, cdb: bytes, alloc: int):
+        op = cdb[0]
+        if op == 0x00:                                   # TEST UNIT READY
+            return (STATUS_GOOD, 0, 0, 0, b'')
+        if op == 0x12:                                   # INQUIRY
+            return (STATUS_GOOD, 0, 0, 0, self.inquiry_data(img)[:alloc or 36])
+        if op == 0x25:                                   # READ CAPACITY(10)
+            return (STATUS_GOOD, 0, 0, 0, self.read_capacity10(img))
+        if op == 0x1A:                                   # MODE SENSE(6)
+            return (STATUS_GOOD, 0, 0, 0, self.mode_sense6(img, cdb)[:alloc or 255])
+        if op in (0x08, 0x28):                           # READ(6)/READ(10)
+            lba, blocks = self.rw_params(cdb)
+            data = img.read(lba, blocks)
+            if data is None:
+                return (STATUS_CHECK_CONDITION, SENSE_ILLEGAL_REQUEST, 0x21, 0, b'')
+            return (STATUS_GOOD, 0, 0, 0, data)
+        # Unknown command.
+        return (STATUS_CHECK_CONDITION, SENSE_ILLEGAL_REQUEST, 0x20, 0, b'')
+
+    def rw_params(self, cdb: bytes):
+        if cdb[0] in (0x08, 0x0A):                       # READ(6)/WRITE(6)
+            lba = ((cdb[1] & 0x1F) << 16) | (cdb[2] << 8) | cdb[3]
+            blocks = cdb[4] or 256                       # a length of 0 means 256
+        else:                                            # READ(10)/WRITE(10)
+            lba = int.from_bytes(cdb[2:6], 'big')
+            blocks = int.from_bytes(cdb[7:9], 'big')
+        return lba, blocks
+
+    # --- Request handling ----------------------------------------------------
+
+    def reply(self, stream_id, status, sk, asc, ascq, actual):
+        self.a314d.send_data(stream_id, struct.pack(RES_FMT, CMD_RES, status, sk, asc, ascq, 0, 0, actual))
+
+    def process_stream_data(self, stream_id: int, data: bytes):
+        kind, unit, cdb_len, _, cdb, direction, _, _, data_length, address = struct.unpack(REQ_FMT, data)
+        cdb = cdb[:cdb_len]
+
+        img = self.images.get(unit)
+        if img is None:
+            self.reply(stream_id, STATUS_CHECK_CONDITION, SENSE_NOT_READY, 0x3A, 0, 0)
+            return
+
+        if direction == DIR_WRITE:
+            self.mem_read_queue.append((stream_id, unit, bytes(cdb)))
+            self.a314d.send_read_mem_req(address, data_length)
+            return
+
+        status, sk, asc, ascq, respdata = self.exec_read(img, cdb, data_length)
+
+        if direction == DIR_READ and respdata and address:
+            self.mem_write_queue.append((stream_id, status, sk, asc, ascq, len(respdata)))
+            self.a314d.send_write_mem_req(address, respdata)
+        else:
+            self.reply(stream_id, status, sk, asc, ascq, len(respdata))
+
+    def process_write_mem_res(self):
+        stream_id, status, sk, asc, ascq, actual = self.mem_write_queue.pop(0)
+        if stream_id == self.current_stream_id:
+            self.reply(stream_id, status, sk, asc, ascq, actual)
+
+    def process_read_mem_res(self, data: bytes):
+        stream_id, unit, cdb = self.mem_read_queue.pop(0)
+        if stream_id != self.current_stream_id:
+            return
+        img = self.images.get(unit)
+        if img is None or cdb[0] not in (0x0A, 0x2A):  # WRITE(6)/WRITE(10)
+            self.reply(stream_id, STATUS_CHECK_CONDITION, SENSE_ILLEGAL_REQUEST, 0x20, 0, 0)
+            return
+        lba, _ = self.rw_params(cdb)
+        if img.write(lba, data):
+            self.reply(stream_id, STATUS_GOOD, 0, 0, 0, len(data))
+        else:
+            self.reply(stream_id, STATUS_CHECK_CONDITION, SENSE_ILLEGAL_REQUEST, 0x21, 0, 0)
+
+    def process_drv_msg(self, stream_id: int, ptype: int, payload: bytes):
+        if ptype == self.a314d.MSG_CONNECT:
+            if payload == SERVICE_NAME.encode() and self.current_stream_id is None:
+                logger.info('Amiga connected to scsi service')
+                self.current_stream_id = stream_id
+                self.a314d.send_connect_response(stream_id, 0)
+            else:
+                self.a314d.send_connect_response(stream_id, 3)
+        elif ptype == self.a314d.MSG_READ_MEM_RES:
+            self.process_read_mem_res(payload)
+        elif ptype == self.a314d.MSG_WRITE_MEM_RES:
+            self.process_write_mem_res()
+        elif self.current_stream_id == stream_id:
+            if ptype == self.a314d.MSG_DATA:
+                self.process_stream_data(stream_id, payload)
+            elif ptype == self.a314d.MSG_RESET:
+                self.current_stream_id = None
+                logger.info('Amiga disconnected from scsi service')
+
+    def handle_a314d_readable(self):
+        buf = self.a314d.drv.recv(8192)
+        if not buf:
+            logger.error('Connection to a314d closed, shutting down')
+            exit(-1)
+
+        self.rbuf += buf
+        while len(self.rbuf) >= 9:
+            (plen, stream_id, ptype) = struct.unpack('=IIB', self.rbuf[:9])
+            if len(self.rbuf) < 9 + plen:
+                break
+            payload = self.rbuf[9:9 + plen]
+            self.rbuf = self.rbuf[9 + plen:]
+            self.process_drv_msg(stream_id, ptype, payload)
+
+    def run(self):
+        self.load_config()
+        logger.info('SCSI service is running')
+
+        while True:
+            try:
+                rl, _, _ = select.select([self.a314d], [], [], 10.0)
+            except KeyboardInterrupt:
+                break
+            for s in rl:
+                if s == self.a314d:
+                    self.handle_a314d_readable()
+
+        self.a314d.close()
+        logger.info('SCSI service stopped')
+
+
+if __name__ == '__main__':
+    ScsiService().run()

--- a/Software/scsi/scsi.py
+++ b/Software/scsi/scsi.py
@@ -219,6 +219,9 @@ class ScsiService(object):
 
         status, sk, asc, ascq, respdata = self.exec_read(img, cdb, data_length)
 
+        if len(respdata) > data_length:
+            respdata = respdata[:data_length]
+
         if direction == DIR_READ and respdata and address:
             self.mem_write_queue.append((stream_id, status, sk, asc, ascq, len(respdata)))
             self.a314d.send_write_mem_req(address, respdata)

--- a/Software/scsi/scsicmd.c
+++ b/Software/scsi/scsicmd.c
@@ -1,0 +1,156 @@
+#include <exec/types.h>
+#include <exec/errors.h>
+
+#include <devices/scsidisk.h>
+
+#include <string.h>
+
+#include "a314scsi.h"
+#include "a314scsi_protocol.h"
+#include "scsi.h"
+#include "kprintf.h"
+
+// Response layouts only. CDBs are assembled byte-wise
+#pragma pack(push, 1)
+
+struct ReadCapacityData
+{
+    ULONG last_lba;
+    ULONG block_size;
+};
+
+#pragma pack(pop)
+
+static UBYTE shift_for(ULONG block_size)
+{
+    UBYTE s = 0;
+    while ((1UL << s) < block_size && s < 31)
+    {
+        s++;
+    }
+    return s;
+}
+
+// Build a SCSICmd around a CDB and run it through the a314 transport.
+static LONG run_cdb(struct A314ScsiBase* base, struct Drive* d, UBYTE* cdb, UBYTE cdb_len, APTR data, ULONG length,
+                    UBYTE dir)
+{
+    struct SCSICmd cmd;
+
+    memset(&cmd, 0, sizeof(cmd));
+    cmd.scsi_Data = (UWORD*)data;
+    cmd.scsi_Length = length;
+    cmd.scsi_Command = cdb;
+    cmd.scsi_CmdLength = cdb_len;
+    cmd.scsi_Flags = SCSIF_AUTOSENSE | ((dir == A314SCSI_DIR_READ) ? SCSIF_READ : 0);
+    cmd.scsi_SenseData = d->sense;
+    cmd.scsi_SenseLength = sizeof(d->sense);
+
+    return a314_scsi(base, d, &cmd);
+}
+
+LONG scsi_test_ready(struct A314ScsiBase* base, struct Drive* d)
+{
+    UBYTE cdb[6];
+
+    memset(cdb, 0, sizeof(cdb));
+    cdb[0] = SCSI_CMD_TEST_UNIT_READY;
+    return run_cdb(base, d, cdb, 6, NULL, 0, A314SCSI_DIR_NONE);
+}
+
+LONG scsi_inquiry(struct A314ScsiBase* base, struct Drive* d)
+{
+    UBYTE cdb[6];
+    UBYTE buf[36];
+
+    memset(cdb, 0, sizeof(cdb));
+    cdb[0] = SCSI_CMD_INQUIRY;
+    cdb[4] = sizeof(buf);
+
+    memset(buf, 0, sizeof(buf));
+    LONG err = run_cdb(base, d, cdb, 6, buf, sizeof(buf), A314SCSI_DIR_READ);
+    if (err)
+    {
+        return err;
+    }
+
+    d->devtype = buf[0] & SCSI_INQ_PDT_MASK;
+    if (buf[1] & SCSI_INQ_RMB)
+    {
+        d->flags |= DRVF_REMOVABLE;
+    }
+
+    return 0;
+}
+
+LONG scsi_read_capacity(struct A314ScsiBase* base, struct Drive* d)
+{
+    UBYTE cdb[10];
+    UBYTE buf[8];
+
+    memset(cdb, 0, sizeof(cdb));
+    cdb[0] = SCSI_CMD_READ_CAPACITY_10;
+    memset(buf, 0, sizeof(buf));
+
+    LONG err = run_cdb(base, d, cdb, 10, buf, sizeof(struct ReadCapacityData), A314SCSI_DIR_READ);
+    if (err)
+    {
+        return err;
+    }
+
+    struct ReadCapacityData* cap = (struct ReadCapacityData*)buf;
+    ULONG bsize = cap->block_size;
+
+    d->blocks = cap->last_lba + 1;
+
+    if (bsize < 256 || bsize > 8192)
+    {
+        bsize = 512;
+    }
+    d->blocksize = bsize;
+    d->blockshift = shift_for(bsize);
+
+    return 0;
+}
+
+LONG scsi_mode_sense_wp(struct A314ScsiBase* base, struct Drive* d)
+{
+    UBYTE cdb[6];
+    UBYTE buf[4];
+
+    memset(cdb, 0, sizeof(cdb));
+    cdb[0] = SCSI_CMD_MODE_SENSE_6;
+    cdb[2] = SCSI_MODE_PAGE_RETURN_ALL; // the header carries the WP bit
+    cdb[4] = sizeof(buf);
+
+    memset(buf, 0, sizeof(buf));
+    LONG err = run_cdb(base, d, cdb, 6, buf, sizeof(buf), A314SCSI_DIR_READ);
+    if (err)
+    {
+        return err; // not fatal for discovery
+    }
+
+    if (buf[2] & SCSI_MODE_HDR_WP)
+    {
+        d->flags |= DRVF_WRITEPROT;
+    }
+
+    return 0;
+}
+
+LONG scsi_rw(struct A314ScsiBase* base, struct Drive* d, ULONG lba, ULONG blocks, APTR buf, BOOL write)
+{
+    UBYTE cdb[10];
+    ULONG length = blocks << d->blockshift;
+    UBYTE dir = write ? A314SCSI_DIR_WRITE : A314SCSI_DIR_READ;
+
+    memset(cdb, 0, sizeof(cdb));
+    cdb[0] = write ? SCSI_CMD_WRITE_10 : SCSI_CMD_READ_10;
+    cdb[2] = (UBYTE)(lba >> 24);
+    cdb[3] = (UBYTE)(lba >> 16);
+    cdb[4] = (UBYTE)(lba >> 8);
+    cdb[5] = (UBYTE)lba;
+    cdb[7] = (UBYTE)(blocks >> 8);
+    cdb[8] = (UBYTE)blocks;
+    return run_cdb(base, d, cdb, 10, buf, length, dir);
+}


### PR DESCRIPTION
It can be ROM'd / LoadModule(), but also ran as a stand-alone CLI (`"DEVS:a314scsi.device"`) to just bring up the mounted volumes. And it can be used with HDToolBox (`"Tools/HDToolBox DEVS:a314scsi.device"`) to configure the images.

Tested with A500 / Kick 1.3 and A1200 / Kick 3.1.